### PR TITLE
Misc Scene3D performance improvements

### DIFF
--- a/RSDKv5/RSDK/Graphics/Scene3D.hpp
+++ b/RSDKv5/RSDK/Graphics/Scene3D.hpp
@@ -154,10 +154,13 @@ inline void Prepare3DScene(uint16 sceneID)
         scn->vertexCount = 0;
         scn->faceCount   = 0;
 
+#if RETRO_PLATFORM != RETRO_KALLISTIOS
+        // These memsets are useless since we zero'd the vertex/face counts, so just ignore them.
         memset(scn->vertices, 0, sizeof(Scene3DVertex) * scn->vertLimit);
         memset(scn->normals, 0, sizeof(Scene3DVertex) * scn->vertLimit);
         memset(scn->faceVertCounts, 0, sizeof(uint8) * scn->vertLimit);
         memset(scn->faceBuffer, 0, sizeof(Scene3DFace) * scn->vertLimit);
+#endif
     }
 }
 


### PR DESCRIPTION
Add some generic optimizations I've used in my port:

* Remove unnecessary memset(0) that are called multiple times per frame.
* Replace insertion sort with std::sort for faster face sorting.

Below is some gameplay running on hardware (compiled in CMake Release `-O3` using GCC 13.1, with `pvr_wait_ready()` commented out).

Before:

https://github.com/michael-fadely/RSDKv5-Decompilation/assets/15063879/c1ecc296-5639-4c31-bde6-3de7168fbd59

After:

https://github.com/michael-fadely/RSDKv5-Decompilation/assets/15063879/1d3028be-172d-4cc4-857e-e08e3cd9356d


This definitely helps when dealing with more polygons: you can see the `Before` gameplay slowing down when blue spheres' shadows show up (they're drawn as a 3D entity).