### PR TITLE
Misc platform/build code cleanup

### DIFF
--- a/RSDKv5/RSDK/Audio/Audio.cpp
+++ b/RSDKv5/RSDK/Audio/Audio.cpp
@@ -14,13 +14,13 @@ using namespace RSDK;
 #define STB_VORBIS_NO_STDIO
 #define STB_VORBIS_NO_INTEGER_CONVERSION
 
-// DCFIXME: should define some RETRO_AUDIODEVICE_*
-#if !defined(_arch_dreamcast)
+// DCFIXME: Stub stb_vorbis for now
+#if RETRO_PLATFORM != RETRO_KALLISTIOS
 #include "stb_vorbis/stb_vorbis.c"
 
 stb_vorbis *vorbisInfo = NULL;
 stb_vorbis_alloc vorbisAlloc;
-#endif  // !defined(_arch_dreamcast)
+#endif  // RETRO_PLATFORM != RETRO_KALLISTIOS
 
 SFXInfo RSDK::sfxList[SFX_COUNT];
 ChannelInfo RSDK::channels[CHANNEL_COUNT];
@@ -36,10 +36,6 @@ int32 streamLoopPoint  = 0;
 
 float linearInterpolationLookup[LINEAR_INTERPOLATION_LOOKUP_LENGTH];
 
-// DCFIXME: should define some RETRO_AUDIODEVICE_*
-#if defined(_arch_dreamcast)
-#include "KallistiOS/KallistiOSAudioDevice.cpp"
-#else  // defined(_arch_dreamcast)
 
 #if RETRO_AUDIODEVICE_XAUDIO
 #include "XAudio/XAudioDevice.cpp"
@@ -49,9 +45,9 @@ float linearInterpolationLookup[LINEAR_INTERPOLATION_LOOKUP_LENGTH];
 #include "PortAudio/PortAudioDevice.cpp"
 #elif RETRO_AUDIODEVICE_OBOE
 #include "Oboe/OboeAudioDevice.cpp"
+#elif RETRO_AUDIODEVICE_KALLISTIOS
+#include "KallistiOS/KallistiOSAudioDevice.cpp"
 #endif
-
-#endif  // !defined(_arch_dreamcast)
 
 uint8 AudioDeviceBase::initializedAudioChannels = false;
 uint8 AudioDeviceBase::audioState               = 0;
@@ -60,7 +56,7 @@ uint8 AudioDeviceBase::audioFocus               = 0;
 void AudioDeviceBase::Release()
 {
     // This is missing, meaning that the garbage collector will never reclaim stb_vorbis's buffer.
-#if !RETRO_USE_ORIGINAL_CODE && !defined(_arch_dreamcast) // DCFIXME
+#if !RETRO_USE_ORIGINAL_CODE && RETRO_PLATFORM != RETRO_KALLISTIOS // DCFIXME
     stb_vorbis_close(vorbisInfo);
     vorbisInfo = NULL;
 #endif
@@ -196,7 +192,7 @@ void AudioDeviceBase::InitAudioChannels()
 
 void RSDK::UpdateStreamBuffer(ChannelInfo *channel)
 {
-#if defined(_arch_dreamcast)
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
     DC_STUB();
 #else
     int32 bufferRemaining = MIX_BUFFER_SIZE;
@@ -228,7 +224,7 @@ void RSDK::UpdateStreamBuffer(ChannelInfo *channel)
 
 void RSDK::LoadStream(ChannelInfo *channel)
 {
-#if defined(_arch_dreamcast)
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
     DC_STUB();
 #else
     if (channel->state != CHANNEL_LOADING_STREAM)
@@ -268,7 +264,7 @@ void RSDK::LoadStream(ChannelInfo *channel)
 
 int32 RSDK::PlayStream(const char *filename, uint32 slot, uint32 startPos, uint32 loopPoint, bool32 loadASync)
 {
-#if defined(_arch_dreamcast)
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
     DC_STUB();
     return -1;
 #else
@@ -455,8 +451,7 @@ void RSDK::LoadSfxToSlot(char *filename, uint8 slot, uint8 plays, uint8 scope)
 
 void RSDK::LoadSfx(char *filename, uint8 plays, uint8 scope)
 {
-    // DCFIXME: should define some RETRO_AUDIODEVICE_*
-#if !defined(_arch_dreamcast)
+#if RETRO_PLATFORM != RETRO_KALLISTIOS
     // Find an empty sound slot.
     uint16 id = -1;
     for (uint32 i = 0; i < SFX_COUNT; ++i) {
@@ -559,7 +554,7 @@ void RSDK::SetChannelAttributes(uint8 channel, float volume, float panning, floa
 
 uint32 RSDK::GetChannelPos(uint32 channel)
 {
-#if defined(_arch_dreamcast)
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
     DC_STUB();
 #else
     if (channel >= CHANNEL_COUNT)
@@ -581,7 +576,7 @@ uint32 RSDK::GetChannelPos(uint32 channel)
 
 double RSDK::GetVideoStreamPos()
 {
-#if defined(_arch_dreamcast)
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
     DC_STUB();
 #else
     if (channels[0].state == CHANNEL_STREAM && AudioDevice::audioState && AudioDevice::initializedAudioChannels && vorbisInfo->current_loc_valid) {

--- a/RSDKv5/RSDK/Audio/Audio.hpp
+++ b/RSDKv5/RSDK/Audio/Audio.hpp
@@ -70,11 +70,6 @@ void LoadSfx(char *filePath, uint8 plays, uint8 scope);
 
 } // namespace RSDK
 
-// DCFIXME: should define some RETRO_AUDIODEVICE_*
-#if defined(_arch_dreamcast)
-#include "KallistiOS/KallistiOSAudioDevice.hpp"
-#else  // defined(_arch_dreamcast)
-
 #if RETRO_AUDIODEVICE_XAUDIO
 #include "XAudio/XAudioDevice.hpp"
 #elif RETRO_AUDIODEVICE_PORT
@@ -83,9 +78,9 @@ void LoadSfx(char *filePath, uint8 plays, uint8 scope);
 #include "SDL2/SDL2AudioDevice.hpp"
 #elif RETRO_AUDIODEVICE_OBOE
 #include "Oboe/OboeAudioDevice.hpp"
+#elif RETRO_AUDIODEVICE_KALLISTIOS
+#include "KallistiOS/KallistiOSAudioDevice.hpp"
 #endif
-
-#endif  // !defined(_arch_dreamcast)
 
 namespace RSDK
 {

--- a/RSDKv5/RSDK/Core/Math.hpp
+++ b/RSDKv5/RSDK/Core/Math.hpp
@@ -3,14 +3,6 @@
 
 namespace RSDK
 {
-#if defined(_arch_dreamcast)
-    // DCFIXME: fixes build. should fix in files that include this header maybe?
-    template <typename T>
-    T abs(T value)
-    {
-        return value < 0 ? -value : value;
-    }
-#endif
 
 // not "math" but works best here
 #define INT_TO_VOID(x) (void *)(size_t)(x)

--- a/RSDKv5/RSDK/Core/RetroEngine.hpp
+++ b/RSDKv5/RSDK/Core/RetroEngine.hpp
@@ -159,7 +159,7 @@ enum GameRegions {
 
 // DCFIXME: is this too large?
 #ifndef SCREEN_XMAX
-#if defined(_arch_dreamcast)
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
 #define SCREEN_XMAX (640)
 #else
 #define SCREEN_XMAX (1280)
@@ -251,12 +251,7 @@ enum GameRegions {
 
 // enables the use of the mod loader
 #ifndef RETRO_USE_MOD_LOADER
-// DCFIXME: disabling mod loader to fix build for now
-#ifdef _arch_dreamcast
-#define RETRO_USE_MOD_LOADER (0)
-#else
 #define RETRO_USE_MOD_LOADER (!RETRO_USE_ORIGINAL_CODE && 1)
-#endif
 #endif
 
 // defines the version of the mod loader, this should be changed ONLY if the ModFunctionTable is updated in any way
@@ -430,8 +425,9 @@ enum GameRegions {
 
 #elif RETRO_PLATFORM == RETRO_KALLISTIOS
 
-// DCFIXME: currently unused
 #define RETRO_RENDERDEVICE_KALLISTIOS (1)
+#define RETRO_AUDIODEVICE_KALLISTIOS  (1)
+#define RETRO_INPUTDEVICE_KALLISTIOS  (1)
 
 #undef RETRO_INPUTDEVICE_KEYBOARD
 #define RETRO_INPUTDEVICE_KEYBOARD (0)
@@ -546,8 +542,8 @@ extern "C" {
 #endif
 #endif
 
-// DCFIXME
-#if !defined(_arch_dreamcast)
+// DCFIXME: No video support for now
+#if RETRO_PLATFORM != RETRO_KALLISTIOS
 #include <theora/theoradec.h>
 #endif
 

--- a/RSDKv5/RSDK/Graphics/Drawing.cpp
+++ b/RSDKv5/RSDK/Graphics/Drawing.cpp
@@ -129,11 +129,6 @@ const RenderVertex rsdkVertexBuffer[24] =
 #endif
 // clang-format on
 
-// DCFIXME: should define some RETRO_RENDERDEVICE_*
-#if defined(_arch_dreamcast)
-#include "KallistiOS/KallistiOSRenderDevice.cpp"
-#else  // defined(_arch_dreamcast)
-
 #if RETRO_RENDERDEVICE_DIRECTX9
 #include "DX9/DX9RenderDevice.cpp"
 #elif RETRO_RENDERDEVICE_DIRECTX11
@@ -146,9 +141,9 @@ const RenderVertex rsdkVertexBuffer[24] =
 #include "Vulkan/VulkanRenderDevice.cpp"
 #elif RETRO_RENDERDEVICE_EGL
 #include "EGL/EGLRenderDevice.cpp"
+#elif RETRO_RENDERDEVICE_KALLISTIOS
+#include "KallistiOS/KallistiOSRenderDevice.cpp"
 #endif
-
-#endif  // !defined(_arch_dreamcast)
 
 RenderDevice::WindowInfo RenderDevice::displayInfo;
 

--- a/RSDKv5/RSDK/Graphics/Drawing.hpp
+++ b/RSDKv5/RSDK/Graphics/Drawing.hpp
@@ -7,7 +7,7 @@ namespace RSDK
 #define SURFACE_COUNT (0x40)
 
 #if RETRO_REV02
-#if defined(_arch_dreamcast)
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
 // DCFIXME: reduced screen count to save RAM (SCREEN_COUNT)
 #define SCREEN_COUNT (1)
 #else
@@ -18,7 +18,7 @@ namespace RSDK
 #endif
 #define CAMERA_COUNT (4)
 
-#if defined(_arch_dreamcast)
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
 #define DEFAULT_PIXWIDTH (320)
 #else
 #define DEFAULT_PIXWIDTH (424)
@@ -249,11 +249,6 @@ private:
     static void GetDisplays();
 };
 
-// DCFIXME: should define some RETRO_RENDERDEVICE_*
-#if defined(_arch_dreamcast)
-#include "KallistiOS/KallistiOSRenderDevice.hpp"
-#else  // defined(_arch_dreamcast)
-
 #if RETRO_RENDERDEVICE_DIRECTX9
 #include "DX9/DX9RenderDevice.hpp"
 #elif RETRO_RENDERDEVICE_DIRECTX11
@@ -266,9 +261,9 @@ private:
 #include "Vulkan/VulkanRenderDevice.hpp"
 #elif RETRO_RENDERDEVICE_EGL
 #include "EGL/EGLRenderDevice.hpp"
+#elif RETRO_RENDERDEVICE_KALLISTIOS
+#include "KallistiOS/KallistiOSRenderDevice.hpp"
 #endif
-
-#endif  // !defined(_arch_dreamcast)
 
 extern DrawList drawGroups[DRAWGROUP_COUNT];
 extern char drawGroupNames[0x10][0x10];

--- a/RSDKv5/RSDK/Graphics/Video.hpp
+++ b/RSDKv5/RSDK/Graphics/Video.hpp
@@ -2,9 +2,9 @@
 #define VIDEO_H
 
 // DCFIXME
-#if defined(_arch_dreamcast)
+#if !defined(_arch_dreamcast)
 #include <ogg/ogg.h>
-#endif  // defined(_arch_dreamcast)
+#endif  // !defined(_arch_dreamcast)
 
 namespace RSDK
 {

--- a/RSDKv5/RSDK/Graphics/Video.hpp
+++ b/RSDKv5/RSDK/Graphics/Video.hpp
@@ -2,15 +2,15 @@
 #define VIDEO_H
 
 // DCFIXME
-#if !defined(_arch_dreamcast)
+#if RETRO_PLATFORM != RETRO_KALLISTIOS
 #include <ogg/ogg.h>
-#endif  // !defined(_arch_dreamcast)
+#endif  // RETRO_PLATFORM != RETRO_KALLISTIOS
 
 namespace RSDK
 {
 
 struct VideoManager {
-    #if !defined(_arch_dreamcast) // DCFIXME
+    #if RETRO_PLATFORM != RETRO_KALLISTIOS // DCFIXME
     static FileInfo file;
 
     static ogg_sync_state oy;
@@ -26,7 +26,7 @@ struct VideoManager {
     static th_pixel_fmt pixelFormat;
     static ogg_int64_t granulePos;
     static bool32 initializing;
-    #endif  // !defined(_arch_dreamcast)
+    #endif  // RETRO_PLATFORM != RETRO_KALLISTIOS
 };
 
 bool32 LoadVideo(const char *filename, double startDelay, bool32 (*skipCallback)());

--- a/RSDKv5/RSDK/Input/Input.cpp
+++ b/RSDKv5/RSDK/Input/Input.cpp
@@ -52,8 +52,7 @@ int32 RSDK::gamePadCount               = 0;
 #include "Paddleboat/PDBInputDevice.cpp"
 #endif
 
-// DCFIXME: should define some RETRO_INPUTDEVICE_KALLISTIOS type thing
-#if RETRO_PLATFORM == RETRO_KALLISTIOS
+#if RETRO_INPUTDEVICE_KALLISTIOS
 #include "KallistiOS/KallistiOSInputDevice.cpp"
 #endif
 
@@ -137,8 +136,7 @@ void RSDK::InitInputDevices()
     SKU::InitPaddleboatInputAPI();
 #endif
 
-    // DCFIXME: should define some RETRO_INPUTDEVICE_KALLISTIOS type thing
-#if RETRO_PLATFORM == RETRO_KALLISTIOS
+#if RETRO_INPUTDEVICE_KALLISTIOS
     SKU::InitKallistiOSInputAPI();
 #endif
 }

--- a/RSDKv5/RSDK/Input/Input.hpp
+++ b/RSDKv5/RSDK/Input/Input.hpp
@@ -504,8 +504,7 @@ extern int32 gamePadCount;
 #include "Paddleboat/PDBInputDevice.hpp"
 #endif
 
-// DCFIXME: should define some RETRO_INPUTDEVICE_KALLISTIOS type thing
-#if RETRO_PLATFORM == RETRO_KALLISTIOS
+#if RETRO_INPUTDEVICE_KALLISTIOS
 #include "KallistiOS/KallistiOSInputDevice.hpp"
 #endif
 

--- a/RSDKv5/RSDK/Scene/Object.hpp
+++ b/RSDKv5/RSDK/Scene/Object.hpp
@@ -15,7 +15,7 @@ namespace RSDK
 // 0x800 scene objects, 0x40 reserved ones, and 0x100 spare slots for creation
 #define RESERVE_ENTITY_COUNT (0x40)
 #define TEMPENTITY_COUNT     (0x100)
-#ifdef _arch_dreamcast
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
 #define SCENEENTITY_COUNT    (256)
 #else
 #define SCENEENTITY_COUNT    (0x800)

--- a/RSDKv5/RSDK/User/Dummy/DummyLeaderboards.cpp
+++ b/RSDKv5/RSDK/User/Dummy/DummyLeaderboards.cpp
@@ -153,10 +153,7 @@ void DummyLeaderboards::TrackScore(LeaderboardID *leaderboard, int32 score, void
 
     std::string str = __FILE__;
     str += ": TrackScore() # TrackScore ";
-    // DCFIXME: kallistios does not have std::to_string seemingly
-#if !defined(_arch_dreamcast)
     str += std::to_string(score);
-#endif  // !defined(_arch_dreamcast)
     str += " \r\n";
     PrintLog(PRINT_NORMAL, str.c_str());
 

--- a/RSDKv5/main.cpp
+++ b/RSDKv5/main.cpp
@@ -1,7 +1,7 @@
 #include "RSDK/Core/RetroEngine.hpp"
 #include "main.hpp"
 
-#if defined(_arch_dreamcast) && RSDK_DEBUG
+#if RETRO_PLATFORM == RETRO_KALLISTIOS && RSDK_DEBUG
 #include <arch/gdb.h>
 #endif
 
@@ -83,7 +83,7 @@ int main(int argc, char *argv[]) { return RSDK_main(argc, argv, (void *)LinkGame
 
 int32 RSDK_main(int32 argc, char **argv, void *linkLogicPtr)
 {
-#if defined(_arch_dreamcast) && RSDK_DEBUG
+#if RETRO_PLATFORM == RETRO_KALLISTIOS && RSDK_DEBUG
     gdb_init();
 #endif
 

--- a/RSDKv5/main.cpp
+++ b/RSDKv5/main.cpp
@@ -1,7 +1,7 @@
 #include "RSDK/Core/RetroEngine.hpp"
 #include "main.hpp"
 
-#if defined(_arch_dreamcast) && defined(RSDK_DEBUG)
+#if defined(_arch_dreamcast) && RSDK_DEBUG
 #include <arch/gdb.h>
 #endif
 
@@ -83,7 +83,7 @@ int main(int argc, char *argv[]) { return RSDK_main(argc, argv, (void *)LinkGame
 
 int32 RSDK_main(int32 argc, char **argv, void *linkLogicPtr)
 {
-#if defined(_arch_dreamcast) && defined(RSDK_DEBUG)
+#if defined(_arch_dreamcast) && RSDK_DEBUG
     gdb_init();
 #endif
 

--- a/platforms/KallistiOS.cmake
+++ b/platforms/KallistiOS.cmake
@@ -2,14 +2,22 @@ project(RetroEngine)
 
 add_executable(RetroEngine ${RETRO_FILES})
 
-set(GAME_STATIC ON CACHE BOOL "Dreamcast may only use static binaries.")
-
-target_link_libraries(RetroEngine m)
-target_include_directories(RetroEngine INTERFACE "${KOS_PORTS}")
-
-if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-    set(RSDK_DEBUG ON)
-    target_compile_definitions(RetroEngine PUBLIC RSDK_DEBUG=1)
+if(NOT GAME_STATIC)
+    message(FATAL_ERROR "GAME_STATIC must be on")
 endif()
 
-set(RETRO_MOD_LOADER OFF)
+# RETRO_REVISION 3 (v5U) will most likely never fit
+if(RETRO_REVISION EQUAL 3)
+    message(FATAL_ERROR "RETRO_REVISION=${RETRO_REVISION} is not supported, use 2 instead")
+endif()
+
+target_include_directories(RetroEngine INTERFACE "${KOS_PORTS}")
+
+# Enable debugging by default on both the engine and game
+option(RSDK_DEBUG "Enable debugging" ON)
+target_compile_definitions(RetroEngine PUBLIC RSDK_DEBUG=$<BOOL:${RSDK_DEBUG}>)
+target_compile_definitions(${GAME_NAME} PUBLIC RSDK_DEBUG=$<BOOL:${RSDK_DEBUG}>)
+
+# Disable some unneeded features to reduce executable size
+set(RETRO_MOD_LOADER OFF CACHE BOOL "Disable mod loader" FORCE)
+set(GAME_INCLUDE_EDITOR OFF CACHE BOOL "Disable unused editor code" FORCE)


### PR DESCRIPTION
Made a couple changes to the KOS CMake file to disable most unneeded features from there (mod loader, editor functions), and added the `RSDK_DEBUG` definition to both the engine and game by default.
The game should now compile with:
```
cmake .. \
-DCMAKE_TOOLCHAIN_FILE=/opt/toolchains/dc/kos/utils/cmake/dreamcast.toolchain.cmake \
-DPLATFORM=KallistiOS \
-DGAME_STATIC=ON \
-DRETRO_REVISION=2
```

With optional `-DRSDK_DEBUG=OFF` to disable gdb init (This makes it possible to still have debug set up in Release mode).
 
Changed the way DC specific code is handled in the engine to be similar to the other platforms, and removed some now unneeded workarounds (old GCC not defining functions like abs and std::to_string).