### PR TITLE
GCC14 Build Fixes, Analog Stick Support, 32MB RAM Expansion Support

### DIFF
--- a/RSDKv5/RSDK/Core/RetroEngine.hpp
+++ b/RSDKv5/RSDK/Core/RetroEngine.hpp
@@ -558,6 +558,10 @@ extern "C" {
 #endif
 #endif
 
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
+#include <kos.h>
+#endif
+
 // DCFIXME: No video support for now
 #if RETRO_PLATFORM != RETRO_KALLISTIOS
 #include <theora/theoradec.h>

--- a/RSDKv5/RSDK/Graphics/KallistiOS/KallistiOSRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/KallistiOS/KallistiOSRenderDevice.cpp
@@ -712,6 +712,19 @@ void RenderDevice::PrepareTexturedPoly(int32 y, int srcBlend, int dstBlend, cons
     }
 }
 
+__noinline
+void rotate(vec3f& p, float cx, float cy, float s, float c) {
+    p.x -= cx;
+    p.y -= cy;
+
+    const auto px = p.x * c - p.y * s;
+    const auto py = p.x * s + p.y * c;
+
+    p.x = px + cx;
+    p.y = py + cy;
+};
+
+
 // static
 void RenderDevice::DrawTexturedPoly(
         int32 x, int32 y,
@@ -761,7 +774,7 @@ void RenderDevice::DrawTexturedPoly(
         .y = p3.y,
         .z = depth
     };
-
+#if 0 /* TODO: Oleg Endo needs to find out why GCC14.1.0 shits itself and ICEs here. */
     if (rotation != 0) {
         const float cx = static_cast<float>(ox) * scaleX;
         const float cy = static_cast<float>(oy) * scaleY;
@@ -786,7 +799,7 @@ void RenderDevice::DrawTexturedPoly(
         rotate(p2);
         rotate(p3);
     }
-
+#endif
     const float u0 = static_cast<float>(sprX0) / surfaceWidth;
     const float u1 = static_cast<float>(sprX1) / surfaceWidth;
 

--- a/RSDKv5/RSDK/Graphics/KallistiOS/KallistiOSRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/KallistiOS/KallistiOSRenderDevice.cpp
@@ -712,19 +712,6 @@ void RenderDevice::PrepareTexturedPoly(int32 y, int srcBlend, int dstBlend, cons
     }
 }
 
-__noinline
-void rotate(vec3f& p, float cx, float cy, float s, float c) {
-    p.x -= cx;
-    p.y -= cy;
-
-    const auto px = p.x * c - p.y * s;
-    const auto py = p.x * s + p.y * c;
-
-    p.x = px + cx;
-    p.y = py + cy;
-};
-
-
 // static
 void RenderDevice::DrawTexturedPoly(
         int32 x, int32 y,
@@ -774,7 +761,7 @@ void RenderDevice::DrawTexturedPoly(
         .y = p3.y,
         .z = depth
     };
-#if 0 /* TODO: Oleg Endo needs to find out why GCC14.1.0 shits itself and ICEs here. */
+
     if (rotation != 0) {
         const float cx = static_cast<float>(ox) * scaleX;
         const float cy = static_cast<float>(oy) * scaleY;
@@ -783,7 +770,13 @@ void RenderDevice::DrawTexturedPoly(
         const float s = sinf(radians);
         const float c = cosf(radians);
 
-        auto rotate = [cx, cy, s, c](vec3f& p) {
+        auto rotate = [cx, cy, s, c](vec3f& p) 
+        /* Allowing this to get inlined causes an ICE in SH-GCC14.
+           Remove __noinline once it's fixed, becaue it's bullshit. */
+#if __GNUC__ >= 14
+        __noinline
+#endif 
+        {
             p.x -= cx;
             p.y -= cy;
 
@@ -799,7 +792,7 @@ void RenderDevice::DrawTexturedPoly(
         rotate(p2);
         rotate(p3);
     }
-#endif
+
     const float u0 = static_cast<float>(sprX0) / surfaceWidth;
     const float u1 = static_cast<float>(sprX1) / surfaceWidth;
 

--- a/RSDKv5/RSDK/Input/KallistiOS/KallistiOSInputDevice.cpp
+++ b/RSDKv5/RSDK/Input/KallistiOS/KallistiOSInputDevice.cpp
@@ -30,6 +30,14 @@ void SKU::KallistiOSInputDevice::ProcessInput(int32 controllerID) {
     retro.keyLeft.press |= (state.buttons & CONT_DPAD_LEFT) != 0;
     retro.keyRight.press |= (state.buttons & CONT_DPAD_RIGHT) != 0;
 
+    float fjoyx = (state.joyx / 128.0f);
+    float fjoyy = (state.joyy / 128.0f);
+
+    retro.keyUp.press |= (fjoyy <= -0.6f);
+    retro.keyDown.press |= (fjoyy >= 0.6f);
+    retro.keyLeft.press |= (fjoyx <= -0.6f);
+    retro.keyLeft.press |= (fjoyx >= 0.6f);
+
     retro.keyA.press |= (state.buttons & CONT_A) != 0;
     retro.keyB.press |= (state.buttons & CONT_B) != 0;
     retro.keyC.press |= (state.buttons & CONT_C) != 0;

--- a/RSDKv5/RSDK/Storage/Storage.cpp
+++ b/RSDKv5/RSDK/Storage/Storage.cpp
@@ -33,22 +33,23 @@ DataStorage RSDK::dataStorage[DATASET_MAX];
 bool32 RSDK::InitStorage()
 {
     // Storage limits.
-#if RETRO_PLATFORM == RETRO_KALLISTIOS
-//    dataStorage[DATASET_STG].storageLimit = (3 * 1024 * 1024) - (640 * 1024); // sonic renders on title screen
-//    dataStorage[DATASET_STG].storageLimit = (5 * 1024 * 1024); // oh god
-//    dataStorage[DATASET_STG].storageLimit = (6 * 1024 * 1024) + ((512 + 64) * 1024); // oh god!!!
-    dataStorage[DATASET_STG].storageLimit = ((DBL_MEM? 8 : 4) * 1024 * 1024); // ok...
-
-    dataStorage[DATASET_MUS].storageLimit = 0;
-    dataStorage[DATASET_SFX].storageLimit = 0;
-    dataStorage[DATASET_STR].storageLimit = (DBL_MEM? 2 : 1) * 32 * 1024;
-    dataStorage[DATASET_TMP].storageLimit = ((DBL_MEM? 6 : 3) * 1024 * 1024);
-#else
-    dataStorage[DATASET_STG].storageLimit = 24 * 1024 * 1024; // 24MB
-    dataStorage[DATASET_MUS].storageLimit = 8 * 1024 * 1024;  //  8MB
-    dataStorage[DATASET_SFX].storageLimit = 32 * 1024 * 1024; // 32MB
-    dataStorage[DATASET_STR].storageLimit = 2 * 1024 * 1024;  //  2MB
-    dataStorage[DATASET_TMP].storageLimit = 8 * 1024 * 1024;  //  8MB
+#if RETRO_PLATFORM == RETRO_KALLISTIOS  /* SAYGA DREAMCAST: Where Sonic Belongs! */
+                                                                       // RAM: 32  / 16  MB
+                                                                       // -----------------
+    dataStorage[DATASET_STG].storageLimit = (DBL_MEM? 4 : 4) * 1024 * 1024; // 4   / 4   MB
+    dataStorage[DATASET_MUS].storageLimit = (DBL_MEM? 4 : 0) * 1024 * 1024; // 4   / 0   MB
+    dataStorage[DATASET_SFX].storageLimit = (DBL_MEM? 2 : 0) * 1024 * 1024; // 2   / 0   MB
+    dataStorage[DATASET_STR].storageLimit = (DBL_MEM? 2 : 1) *   32 * 1024; // 64  / 32  KB
+    dataStorage[DATASET_TMP].storageLimit = (DBL_MEM? 6 : 3) * 1024 * 1024; // 6   / 3   MB
+                                                                     //   -----------------
+#else                                                                // Total: 16+ / 7+  MB 
+                                        /* PCs AND BORING SHIT */
+    dataStorage[DATASET_STG].storageLimit = 24 * 1024 * 1024; // 24 MB
+    dataStorage[DATASET_MUS].storageLimit =  8 * 1024 * 1024; //  8 MB
+    dataStorage[DATASET_SFX].storageLimit = 32 * 1024 * 1024; // 32 MB
+    dataStorage[DATASET_STR].storageLimit =  2 * 1024 * 1024; //  2 MB
+    dataStorage[DATASET_TMP].storageLimit =  8 * 1024 * 1024; //  8 MB
+                                                       // Total: 74 MB LMAO, YEAH RIGHT.
 #endif
 
     for (int32 s = 0; s < DATASET_MAX; ++s) {

--- a/RSDKv5/RSDK/Storage/Storage.cpp
+++ b/RSDKv5/RSDK/Storage/Storage.cpp
@@ -6,6 +6,10 @@ using namespace RSDK;
 #include "Legacy/UserStorageLegacy.cpp"
 #endif
 
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
+#include <kos.h>
+#endif
+
 // Macro to access the header variables of a block of memory.
 // Note that this is pointless if the pointer is already pointing directly at the header rather than the memory after it.
 #define HEADER(memory, header_value) memory[-HEADER_SIZE + header_value]
@@ -33,12 +37,12 @@ bool32 RSDK::InitStorage()
 //    dataStorage[DATASET_STG].storageLimit = (3 * 1024 * 1024) - (640 * 1024); // sonic renders on title screen
 //    dataStorage[DATASET_STG].storageLimit = (5 * 1024 * 1024); // oh god
 //    dataStorage[DATASET_STG].storageLimit = (6 * 1024 * 1024) + ((512 + 64) * 1024); // oh god!!!
-    dataStorage[DATASET_STG].storageLimit = (4 * 1024 * 1024); // ok...
+    dataStorage[DATASET_STG].storageLimit = ((DBL_MEM? 8 : 4) * 1024 * 1024); // ok...
 
     dataStorage[DATASET_MUS].storageLimit = 0;
     dataStorage[DATASET_SFX].storageLimit = 0;
-    dataStorage[DATASET_STR].storageLimit = 32 * 1024;
-    dataStorage[DATASET_TMP].storageLimit = (3 * 1024 * 1024);
+    dataStorage[DATASET_STR].storageLimit = (DBL_MEM? 2 : 1) * 32 * 1024;
+    dataStorage[DATASET_TMP].storageLimit = ((DBL_MEM? 6 : 3) * 1024 * 1024);
 #else
     dataStorage[DATASET_STG].storageLimit = 24 * 1024 * 1024; // 24MB
     dataStorage[DATASET_MUS].storageLimit = 8 * 1024 * 1024;  //  8MB

--- a/RSDKv5/RSDK/Storage/Storage.cpp
+++ b/RSDKv5/RSDK/Storage/Storage.cpp
@@ -6,10 +6,6 @@ using namespace RSDK;
 #include "Legacy/UserStorageLegacy.cpp"
 #endif
 
-#if RETRO_PLATFORM == RETRO_KALLISTIOS
-#include <kos.h>
-#endif
-
 // Macro to access the header variables of a block of memory.
 // Note that this is pointless if the pointer is already pointing directly at the header rather than the memory after it.
 #define HEADER(memory, header_value) memory[-HEADER_SIZE + header_value]

--- a/RSDKv5/RSDK/User/Core/UserStorage.cpp
+++ b/RSDKv5/RSDK/User/Core/UserStorage.cpp
@@ -1234,7 +1234,7 @@ void RSDK::SKU::InitUserDirectory()
 
 #elif RETRO_PLATFORM == RETRO_KALLISTIOS
 
-    SKU::SetUserFileCallbacks("/pc/", NULL, NULL);
+    SKU::SetUserFileCallbacks("/cd/", NULL, NULL);
 
 #else
 

--- a/RSDKv5/RSDK/User/Core/UserStorage.cpp
+++ b/RSDKv5/RSDK/User/Core/UserStorage.cpp
@@ -1234,10 +1234,6 @@ void RSDK::SKU::InitUserDirectory()
 
 #elif RETRO_PLATFORM == RETRO_KALLISTIOS
 
-#   ifndef KOS_USER_DIR
-#       define KOS_USER_DIR "/cd/"
-#   endif
-
     SKU::SetUserFileCallbacks(KOS_USER_DIR, NULL, NULL);
 
 #else

--- a/RSDKv5/RSDK/User/Core/UserStorage.cpp
+++ b/RSDKv5/RSDK/User/Core/UserStorage.cpp
@@ -1234,7 +1234,7 @@ void RSDK::SKU::InitUserDirectory()
 
 #elif RETRO_PLATFORM == RETRO_KALLISTIOS
 
-    SKU::SetUserFileCallbacks("/cd/", NULL, NULL);
+    SKU::SetUserFileCallbacks("/pc/", NULL, NULL);
 
 #else
 

--- a/RSDKv5/RSDK/User/Core/UserStorage.cpp
+++ b/RSDKv5/RSDK/User/Core/UserStorage.cpp
@@ -1234,7 +1234,11 @@ void RSDK::SKU::InitUserDirectory()
 
 #elif RETRO_PLATFORM == RETRO_KALLISTIOS
 
-    SKU::SetUserFileCallbacks("/cd/", NULL, NULL);
+#   ifndef KOS_USER_DIR
+#       define KOS_USER_DIR "/cd/"
+#   endif
+
+    SKU::SetUserFileCallbacks(KOS_USER_DIR, NULL, NULL);
 
 #else
 

--- a/RSDKv5/main.cpp
+++ b/RSDKv5/main.cpp
@@ -79,7 +79,7 @@ int main(int argc, char *argv[]) { return RSDK_main(argc, argv, (void *)LinkGame
 #endif
 
 #if RETRO_PLATFORM == RETRO_KALLISTIOS
-KOS_INIT_FLAGS(INIT_IRQ | INIT_CONTROLLER);
+KOS_INIT_FLAGS(INIT_IRQ | INIT_CONTROLLER | INIT_CDROM);
 #endif
 int32 RSDK_main(int32 argc, char **argv, void *linkLogicPtr)
 {

--- a/RSDKv5/main.cpp
+++ b/RSDKv5/main.cpp
@@ -1,16 +1,12 @@
-#include "RSDK/Core/RetroEngine.hpp"
-#include "main.hpp"
-
 #if RETRO_PLATFORM == RETRO_KALLISTIOS
-#if RSDK_DEBUG
-#include <arch/gdb.h>
-#endif
-
 #include <kos.h>
 
 KOS_INIT_FLAGS(INIT_IRQ | INIT_CONTROLLER);
 
 #endif
+
+#include "RSDK/Core/RetroEngine.hpp"
+#include "main.hpp"
 
 #if RETRO_STANDALONE
 #define LinkGameLogic RSDK::LinkGameLogic
@@ -91,8 +87,13 @@ int main(int argc, char *argv[]) { return RSDK_main(argc, argv, (void *)LinkGame
 
 int32 RSDK_main(int32 argc, char **argv, void *linkLogicPtr)
 {
-#if RETRO_PLATFORM == RETRO_KALLISTIOS && RSDK_DEBUG
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
+#if RSDK_DEBUG
     gdb_init();
+#endif
+    cont_btn_callback(0, CONT_RESET_BUTTONS, [](uint8_t, uint32_t) {
+        exit(EXIT_SUCCESS);
+    });
 #endif
 
     RSDK::linkGameLogic = (RSDK::LogicLinkHandle)linkLogicPtr;

--- a/RSDKv5/main.cpp
+++ b/RSDKv5/main.cpp
@@ -1,10 +1,3 @@
-#if RETRO_PLATFORM == RETRO_KALLISTIOS
-#include <kos.h>
-
-KOS_INIT_FLAGS(INIT_IRQ | INIT_CONTROLLER);
-
-#endif
-
 #include "RSDK/Core/RetroEngine.hpp"
 #include "main.hpp"
 
@@ -85,6 +78,9 @@ void android_main(struct android_app *ap)
 int main(int argc, char *argv[]) { return RSDK_main(argc, argv, (void *)LinkGameLogic); }
 #endif
 
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
+KOS_INIT_FLAGS(INIT_IRQ | INIT_CONTROLLER);
+#endif
 int32 RSDK_main(int32 argc, char **argv, void *linkLogicPtr)
 {
 #if RETRO_PLATFORM == RETRO_KALLISTIOS

--- a/dependencies/all/miniz/miniz.c
+++ b/dependencies/all/miniz/miniz.c
@@ -25,8 +25,6 @@
  *
  **************************************************************************/
 
-
-
 typedef unsigned char mz_validate_uint16[sizeof(mz_uint16) == 2 ? 1 : -1];
 typedef unsigned char mz_validate_uint32[sizeof(mz_uint32) == 4 ? 1 : -1];
 typedef unsigned char mz_validate_uint64[sizeof(mz_uint64) == 8 ? 1 : -1];
@@ -2982,7 +2980,6 @@ void tinfl_decompressor_free(tinfl_decompressor *pDecomp)
  *
  **************************************************************************/
 
-
 #ifndef MINIZ_NO_ARCHIVE_APIS
 
 #ifdef __cplusplus
@@ -3110,9 +3107,6 @@ static FILE *mz_freopen(const char *pPath, const char *pMode, FILE *pStream)
 #endif /* #ifdef MINIZ_NO_STDIO */
 
 #define MZ_TOLOWER(c) ((((c) >= 'A') && ((c) <= 'Z')) ? ((c) - 'A' + 'a') : (c))
-
-
-extern int utime(const char *path, struct utimbuf *times);
 
 /* Various ZIP archive enums. To completely avoid cross platform compiler alignment and platform endian issues, miniz.c doesn't use structs for any of this stuff. */
 enum

--- a/dependencies/all/miniz/miniz.c
+++ b/dependencies/all/miniz/miniz.c
@@ -3111,6 +3111,9 @@ static FILE *mz_freopen(const char *pPath, const char *pMode, FILE *pStream)
 
 #define MZ_TOLOWER(c) ((((c) >= 'A') && ((c) <= 'Z')) ? ((c) - 'A' + 'a') : (c))
 
+
+extern int utime(const char *path, struct utimbuf *times);
+
 /* Various ZIP archive enums. To completely avoid cross platform compiler alignment and platform endian issues, miniz.c doesn't use structs for any of this stuff. */
 enum
 {

--- a/dependencies/all/miniz/miniz.c
+++ b/dependencies/all/miniz/miniz.c
@@ -25,6 +25,8 @@
  *
  **************************************************************************/
 
+
+
 typedef unsigned char mz_validate_uint16[sizeof(mz_uint16) == 2 ? 1 : -1];
 typedef unsigned char mz_validate_uint32[sizeof(mz_uint32) == 4 ? 1 : -1];
 typedef unsigned char mz_validate_uint64[sizeof(mz_uint64) == 8 ? 1 : -1];
@@ -2979,6 +2981,7 @@ void tinfl_decompressor_free(tinfl_decompressor *pDecomp)
  * THE SOFTWARE.
  *
  **************************************************************************/
+
 
 #ifndef MINIZ_NO_ARCHIVE_APIS
 

--- a/dependencies/all/miniz/miniz.c
+++ b/dependencies/all/miniz/miniz.c
@@ -3106,6 +3106,15 @@ static FILE *mz_freopen(const char *pPath, const char *pMode, FILE *pStream)
 #endif /* #ifdef _MSC_VER */
 #endif /* #ifdef MINIZ_NO_STDIO */
 
+/* Required temporary fix for a Newlib bug in that it never declares this
+   function for the SuperH architecture, and now, in GCC14, implicit 
+   function declarations are deprecated and become hard errors.
+   
+   This is currently being fixed in KOS and will be removed shortly. */
+#if RETRO_PLATFORM == RETRO_KALLISTIOS && __GNUC__ >= 14
+extern int utime(const char *path, struct utimbuf *times);
+#endif
+
 #define MZ_TOLOWER(c) ((((c) >= 'A') && ((c) <= 'Z')) ? ((c) - 'A' + 'a') : (c))
 
 /* Various ZIP archive enums. To completely avoid cross platform compiler alignment and platform endian issues, miniz.c doesn't use structs for any of this stuff. */

--- a/platforms/KallistiOS.cmake
+++ b/platforms/KallistiOS.cmake
@@ -18,6 +18,9 @@ option(RSDK_DEBUG "Enable debugging" ON)
 target_compile_definitions(RetroEngine PUBLIC RSDK_DEBUG=$<BOOL:${RSDK_DEBUG}>)
 target_compile_definitions(${GAME_NAME} PUBLIC RSDK_DEBUG=$<BOOL:${RSDK_DEBUG}>)
 
+option(KOS_USER_DIR "Root directory fo the KOS VFS which get set as the RSDK User directory." "/pc/")
+target_compile_definitions(RetroEngine PUBLIC KOS_USER_DIR="${KOS_USER_DIR}")
+
 # Disable some unneeded features to reduce executable size
 set(RETRO_MOD_LOADER OFF CACHE BOOL "Disable mod loader" FORCE)
 set(GAME_INCLUDE_EDITOR OFF CACHE BOOL "Disable unused editor code" FORCE)

--- a/platforms/KallistiOS.cmake
+++ b/platforms/KallistiOS.cmake
@@ -18,7 +18,7 @@ option(RSDK_DEBUG "Enable debugging" ON)
 target_compile_definitions(RetroEngine PUBLIC RSDK_DEBUG=$<BOOL:${RSDK_DEBUG}>)
 target_compile_definitions(${GAME_NAME} PUBLIC RSDK_DEBUG=$<BOOL:${RSDK_DEBUG}>)
 
-option(KOS_USER_DIR "Root directory fo the KOS VFS which get set as the RSDK User directory." "/pc/")
+option(KOS_USER_DIR "Root directory for the KOS VFS which get set as the RSDK User directory." "/cd/")
 target_compile_definitions(RetroEngine PUBLIC KOS_USER_DIR="${KOS_USER_DIR}")
 
 # Disable some unneeded features to reduce executable size


### PR DESCRIPTION
1) utime() forward declaration added to miniz.c
    * GCC14.1.0 no longer allows implicit declarations of functions in C
      anymore, and this wasn't ever declared in any Newlib header for
SH.
2) Had to remove the stateful C++ lamdda for rotate() from
   RenderDevice::DrawTexturedPoly() and prevent the compiler from
inlining it, as it caused an ICE.
3) Added support for analog stick movement.
4) Added support for 32MB Dreamcasts
    * doubled the sizes of buffers within Storage.cpp when 32MB is
      detected.