### PR TITLE
Revamped KallistiOS Input Back-End.

### DIFF
--- a/RSDKv5/RSDK/Input/Input.hpp
+++ b/RSDKv5/RSDK/Input/Input.hpp
@@ -1,9 +1,11 @@
 #ifndef INPUT_H
 #define INPUT_H
 
+#ifdef _arch_dreamcast
 #include <functional>
 #include <array>
 #include <string>
+#endif
 
 namespace RSDK
 {
@@ -11,7 +13,7 @@ namespace RSDK
 #define PLAYER_COUNT      (4)
 #define INPUTDEVICE_COUNT (4)
 
-#define INPUT_DEADZONE (0.3f)
+#define INPUT_DEADZONE (0.3)
 
 enum InputIDs {
     INPUT_UNASSIGNED = -2,
@@ -44,7 +46,7 @@ enum InputDeviceIDs {
     DEVICE_SWITCH_JOY_GRIP,
     DEVICE_SWITCH_JOY_L,
     DEVICE_SWITCH_JOY_R,
-    DEVICE_SWITCH_PRO
+    DEVICE_SWITCH_PRO,
 };
 
 enum InputDeviceAPIs {

--- a/RSDKv5/RSDK/Input/Input.hpp
+++ b/RSDKv5/RSDK/Input/Input.hpp
@@ -11,7 +11,11 @@ namespace RSDK
 {
 
 #define PLAYER_COUNT      (4)
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
 #define INPUTDEVICE_COUNT (4)
+#else
+#define INPUTDEVICE_COUNT (0x10)
+#endif
 
 #define INPUT_DEADZONE (0.3)
 

--- a/RSDKv5/RSDK/Input/Input.hpp
+++ b/RSDKv5/RSDK/Input/Input.hpp
@@ -1,13 +1,17 @@
 #ifndef INPUT_H
 #define INPUT_H
 
+#include <functional>
+#include <array>
+#include <string>
+
 namespace RSDK
 {
 
 #define PLAYER_COUNT      (4)
-#define INPUTDEVICE_COUNT (0x10)
+#define INPUTDEVICE_COUNT (4)
 
-#define INPUT_DEADZONE (0.3)
+#define INPUT_DEADZONE (0.3f)
 
 enum InputIDs {
     INPUT_UNASSIGNED = -2,
@@ -40,7 +44,7 @@ enum InputDeviceIDs {
     DEVICE_SWITCH_JOY_GRIP,
     DEVICE_SWITCH_JOY_L,
     DEVICE_SWITCH_JOY_R,
-    DEVICE_SWITCH_PRO,
+    DEVICE_SWITCH_PRO
 };
 
 enum InputDeviceAPIs {

--- a/RSDKv5/RSDK/Input/KallistiOS/KallistiOSInputDevice.cpp
+++ b/RSDKv5/RSDK/Input/KallistiOS/KallistiOSInputDevice.cpp
@@ -5,114 +5,203 @@
 
 #include <RSDK/Core/Stub.hpp>
 
+void SKU::Vmu::FrameBuffer::print(std::string str, unsigned lineSpacing, Rect rect) {
+    vmufb_print_string_into(this, nullptr, rect.x, rect.y,
+                            rect.w, rect.h, lineSpacing, str.c_str());
+    changed = true;
+}
+
+void SKU::Vmu::FrameBuffer::blit(const uint8_t* data, Rect rect) {
+    vmufb_paint_area(this, rect.x, rect.y, rect.w, rect.h, data);
+    changed = true;
+}
+
+void SKU::Vmu::FrameBuffer::fill(bool value, Rect rect) {
+    for(unsigned y = rect.y; y < rect.h; ++y) {
+        for(unsigned x = rect.x; x < rect.w; ++x) {
+            if(value) data[x] |= (1 << y);
+            else data[x] &= ~(1 << y);
+        }
+    }
+    changed = true;
+}
+
+maple_device_t* SKU::Vmu::dev() const {
+    maple_device_t* device = maple_enum_dev(port, slot);
+    return (device && (device->info.functions & MAPLE_FUNC_LCD))?
+            device : nullptr;
+}
+
+vmu_state_t* SKU::Vmu::state() const {
+    if(auto* d = dev(); d)
+        return reinterpret_cast<vmu_state_t*>(maple_dev_status(d));
+    return nullptr;
+}
+
+bool SKU::Vmu::valid() const {
+    return dev() != nullptr;
+}
+
+bool SKU::Vmu::beep(uint8_t tone, std::function<void(void)> task) const {
+    auto* d = dev();
+
+    if(d)
+        vmu_beep_waveform(d, tone, tone / 2, tone, tone / 2);
+
+    task();
+
+    if(d) {
+        vmu_beep_waveform(d, 0, 0, 0, 0);
+        return true;
+    }
+
+    return false;
+}
+
+bool SKU::Vmu::pressed(SKU::Vmu::Button button) const {
+    if(auto* s = state(); s)
+        return (s->buttons.current.raw & static_cast<unsigned>(button));
+
+    return false;
+}
+
+bool SKU::Vmu::tapped(SKU::Vmu::Button button) const {
+    if(auto* s = state(); s)
+        return (s->buttons.previous.raw & static_cast<unsigned>(button));
+
+    return false;
+}
+
+bool SKU::Vmu::update() const {
+    if(auto* d = dev(); fb.changed && d) {
+        vmufb_present(&fb, d);
+        fb.changed = false;
+        return true;
+    }
+
+    return false;
+}
+
 void SKU::KallistiOSInputDevice::UpdateInput() {
-    maple_device_t* mapleDevice = maple_enum_type(this->mapleIndex, MAPLE_FUNC_CONTROLLER);
+    maple_device_t *device = maple_enum_dev(port(), 0);
+    if(device) {
+        active = true;
 
-    if (!mapleDevice) {
-        return;
+        if(device->info.functions & MAPLE_FUNC_CONTROLLER) {
+            gamepadType = (DEVICE_TYPE_CONTROLLER << 8);
+        } else if(device->info.functions & MAPLE_FUNC_KEYBOARD) {
+            gamepadType = (DEVICE_TYPE_KEYBOARD << 8);
+        }
+
+        for(unsigned v = 0; v < 2; ++v)
+            vmu[v].update();
+
+        ProcessInput(!port()? CONT_ANY : CONT_P1 + 1);
+    } else {
+        active = false;
+        gamepadType = DEVICE_TYPE_NONE;
     }
-
-    cont_state_t* mapleState = (cont_state_t*)maple_dev_status(mapleDevice);
-
-    if (!mapleState) {
-        return;
-    }
-
-    this->state = *mapleState;
-    this->ProcessInput(CONT_ANY);
 }
 
 void SKU::KallistiOSInputDevice::ProcessInput(int32 controllerID) {
     auto& retro = controller[controllerID];
+    auto& leftAnalog = stickL[controllerID];
 
-    retro.keyUp.press |= (state.buttons & CONT_DPAD_UP) != 0;
-    retro.keyDown.press |= (state.buttons & CONT_DPAD_DOWN) != 0;
-    retro.keyLeft.press |= (state.buttons & CONT_DPAD_LEFT) != 0;
-    retro.keyRight.press |= (state.buttons & CONT_DPAD_RIGHT) != 0;
+    auto* dev = maple_enum_dev(port(), 0);
+    assert(dev);
 
-    float fjoyx = (state.joyx / 128.0f);
-    float fjoyy = (state.joyy / 128.0f);
+    switch((gamepadType >> 8)) {
+        case DEVICE_TYPE_CONTROLLER: {
+            auto& state = *reinterpret_cast<cont_state_t*>(maple_dev_status(dev));
 
-    retro.keyUp.press |= (fjoyy <= -0.6f);
-    retro.keyDown.press |= (fjoyy >= 0.6f);
-    retro.keyLeft.press |= (fjoyx <= -0.6f);
-    retro.keyRight.press |= (fjoyx >= 0.6f);
+            retro.keyUp.press |= (state.buttons & CONT_DPAD_UP) != 0;
+            retro.keyDown.press |= (state.buttons & CONT_DPAD_DOWN) != 0;
+            retro.keyLeft.press |= (state.buttons & CONT_DPAD_LEFT) != 0;
+            retro.keyRight.press |= (state.buttons & CONT_DPAD_RIGHT) != 0;
 
-    retro.keyA.press |= (state.buttons & CONT_A) != 0;
-    retro.keyB.press |= (state.buttons & CONT_B) != 0;
-    retro.keyC.press |= (state.buttons & CONT_C) != 0;
-    retro.keyX.press |= (state.buttons & CONT_X) != 0;
-    retro.keyY.press |= (state.buttons & CONT_Y) != 0;
-    retro.keyZ.press |= (state.buttons & CONT_Z) != 0;
+            float fjoyx = (state.joyx / 128.0f);
+            float fjoyy = (state.joyy / 128.0f);
 
-    retro.keyStart.press |= (state.buttons & CONT_START) != 0;
-    retro.keySelect.press |= (state.buttons & CONT_D) != 0;
+            leftAnalog.keyUp.press |= (fjoyy <= -0.6f);
+            leftAnalog.keyDown.press |= (fjoyy >= 0.6f);
+            leftAnalog.keyLeft.press |= (fjoyx <= -0.6f);
+            leftAnalog.keyRight.press |= (fjoyx >= 0.6f);
+
+            retro.keyA.press |= (state.buttons & CONT_A) != 0;
+            retro.keyB.press |= (state.buttons & CONT_B) != 0;
+            retro.keyC.press |= (state.buttons & CONT_C) != 0;
+            retro.keyC.press |= (vmu[0].pressed(Vmu::Button::A)
+                              || vmu[1].pressed(Vmu::Button::A));
+
+            retro.keyX.press |= (state.buttons & CONT_X) != 0;
+            retro.keyY.press |= (state.buttons & CONT_Y) != 0;
+            retro.keyZ.press |= (state.buttons & CONT_Z) != 0;
+            retro.keyZ.press |= (vmu[0].pressed(Vmu::Button::B)
+                              || vmu[1].pressed(Vmu::Button::B));
+
+            retro.keyStart.press |= (state.buttons & CONT_START) != 0;
+            retro.keySelect.press |= (state.buttons & CONT_D) != 0;
+            retro.keySelect.press |= (vmu[0].pressed(Vmu::Button::Mode)
+                                   || vmu[1].pressed(Vmu::Button::Mode));
+            break;
+        }
+        case DEVICE_TYPE_KEYBOARD: {
+            auto& kbd = *reinterpret_cast<kbd_state_t*>(maple_dev_status(dev));
+
+            retro.keyUp.press |= kbd.key_states[KBD_KEY_UP].is_down;
+            retro.keyDown.press |= kbd.key_states[KBD_KEY_DOWN].is_down;
+            retro.keyLeft.press |= kbd.key_states[KBD_KEY_LEFT].is_down;
+            retro.keyRight.press |= kbd.key_states[KBD_KEY_RIGHT].is_down;
+
+            leftAnalog.keyUp.press |= retro.keyUp.press;
+            leftAnalog.keyDown.press |= retro.keyDown.press;
+            leftAnalog.keyLeft.press |= retro.keyRight.press;
+            leftAnalog.keyRight.press |= retro.keyLeft.press;
+
+            retro.keyA.press |= kbd.key_states[KBD_KEY_A].is_down;
+            retro.keyB.press |= kbd.key_states[KBD_KEY_B].is_down;
+            retro.keyC.press |= kbd.key_states[KBD_KEY_C].is_down;
+
+            retro.keyX.press |= kbd.key_states[KBD_KEY_X].is_down;
+            retro.keyY.press |= kbd.key_states[KBD_KEY_Y].is_down;
+            retro.keyZ.press |= kbd.key_states[KBD_KEY_Z].is_down;
+
+            retro.keyStart.press |= (kbd.key_states[KBD_KEY_S].is_down
+                                  || kbd.key_states[KBD_KEY_ENTER].is_down);
+            retro.keySelect.press |= kbd.key_states[KBD_KEY_D].is_down;
+            retro.keySelect.press |= kbd.key_states[KBD_KEY_TAB].is_down;
+
+            break;
+        }
+    }
 }
 
 void SKU::KallistiOSInputDevice::CloseDevice() {
     printHere();
 }
 
+namespace {
+    SKU::KallistiOSInputDevice inputDevices[PLAYER_COUNT] = { 0, 1, 2, 3 };
+}
+
 void SKU::InitKallistiOSInputAPI() {
-    for (int32 i = 0; i < PLAYER_COUNT; ++i) {
-        int32 controllerID = i + 1;
-        KallistiOSInputDevice* kosInputDevice = nullptr;
+    // Enable KOS to poll for button input from any attached VMUs.
+    vmu_set_buttons_enabled(true);
 
-        for (int32 d = 0; d < inputDeviceCount; ++d) {
-            if (inputDeviceList[d] && inputDeviceList[d]->id == controllerID) {
-                kosInputDevice = (KallistiOSInputDevice*)inputDeviceList[d];
-            }
-        }
+    inputDeviceCount = PLAYER_COUNT;
+    for(unsigned c = 0; c < PLAYER_COUNT; ++c) {
+        inputDevices[c].disabled = false;
+        inputDevices[c].active = false;
+        inputDevices[c].isAssigned = true;
+        inputDevices[c].gamepadType = DEVICE_TYPE_NONE;
 
-        maple_device_t* mapleDevice = maple_enum_type(i, MAPLE_FUNC_CONTROLLER);
+        inputSlots[c] = CONT_P1 + c;
+        inputDeviceList[c] = &inputDevices[c];
+        inputSlotDevices[c] = &inputDevices[c];
 
-        if (mapleDevice == nullptr) {
-            if (kosInputDevice) {
-                RemoveInputDevice(kosInputDevice);
-            }
-
-            continue;
-        }
-
-        cont_state_t* state = (cont_state_t*)maple_dev_status(mapleDevice);
-
-        if (state == nullptr) {
-            if (kosInputDevice) {
-                RemoveInputDevice(kosInputDevice);
-            }
-
-            continue;
-        }
-
-        if (!kosInputDevice) {
-            if (inputDeviceCount == INPUTDEVICE_COUNT) {
-                continue;
-            }
-
-            if (inputDeviceList[inputDeviceCount] && inputDeviceList[inputDeviceCount]->active) {
-                continue;
-            }
-
-            if (inputDeviceList[inputDeviceCount]) {
-                delete inputDeviceList[inputDeviceCount];
-            }
-
-            kosInputDevice = new KallistiOSInputDevice();
-            inputDeviceList[inputDeviceCount] = kosInputDevice;
-            kosInputDevice->disabled = false;
-            kosInputDevice->id = controllerID;
-            kosInputDevice->active = true;
-
-            for (int32 p = 0; p < PLAYER_COUNT; ++p) {
-                if (inputSlots[p] == controllerID) {
-                    inputSlotDevices[p] = kosInputDevice;
-                    kosInputDevice->isAssigned  = true;
-                }
-            }
-
-            inputDeviceCount++;
-        }
-
-        kosInputDevice->mapleIndex = i;
+        inputDevices[c].vmu[0].fb.print("***********\n"
+                                        "SONIC MANIA\n"
+                                        "***********\n"
+                                        "Fuck da PS2!");
     }
 }

--- a/RSDKv5/RSDK/Input/KallistiOS/KallistiOSInputDevice.cpp
+++ b/RSDKv5/RSDK/Input/KallistiOS/KallistiOSInputDevice.cpp
@@ -5,18 +5,18 @@
 
 #include <RSDK/Core/Stub.hpp>
 
-void SKU::Vmu::FrameBuffer::print(std::string str, unsigned lineSpacing, Rect rect) {
+void SKU::Vmu::FrameBuffer::Print(std::string str, unsigned lineSpacing, Rect rect) {
     vmufb_print_string_into(this, nullptr, rect.x, rect.y,
                             rect.w, rect.h, lineSpacing, str.c_str());
     changed = true;
 }
 
-void SKU::Vmu::FrameBuffer::blit(const uint8_t* data, Rect rect) {
+void SKU::Vmu::FrameBuffer::Blit(const uint8_t* data, Rect rect) {
     vmufb_paint_area(this, rect.x, rect.y, rect.w, rect.h, data);
     changed = true;
 }
 
-void SKU::Vmu::FrameBuffer::fill(bool value, Rect rect) {
+void SKU::Vmu::FrameBuffer::Fill(bool value, Rect rect) {
     for(unsigned y = rect.y; y < rect.h; ++y) {
         for(unsigned x = rect.x; x < rect.w; ++x) {
             if(value) data[x] |= (1 << y);
@@ -26,24 +26,24 @@ void SKU::Vmu::FrameBuffer::fill(bool value, Rect rect) {
     changed = true;
 }
 
-maple_device_t* SKU::Vmu::dev() const {
+maple_device_t* SKU::Vmu::Dev() const {
     maple_device_t* device = maple_enum_dev(port, slot);
     return (device && (device->info.functions & MAPLE_FUNC_LCD))?
             device : nullptr;
 }
 
-vmu_state_t* SKU::Vmu::state() const {
-    if(auto* d = dev(); d)
+vmu_state_t* SKU::Vmu::State() const {
+    if(auto* d = Dev(); d)
         return reinterpret_cast<vmu_state_t*>(maple_dev_status(d));
     return nullptr;
 }
 
-bool SKU::Vmu::valid() const {
-    return dev() != nullptr;
+bool SKU::Vmu::Valid() const {
+    return Dev() != nullptr;
 }
 
-bool SKU::Vmu::beep(uint8_t tone, std::function<void(void)> task) const {
-    auto* d = dev();
+bool SKU::Vmu::Beep(uint8_t tone, std::function<void(void)> task) const {
+    auto* d = Dev();
 
     if(d)
         vmu_beep_waveform(d, tone, tone / 2, tone, tone / 2);
@@ -58,22 +58,22 @@ bool SKU::Vmu::beep(uint8_t tone, std::function<void(void)> task) const {
     return false;
 }
 
-bool SKU::Vmu::pressed(SKU::Vmu::Button button) const {
-    if(auto* s = state(); s)
+bool SKU::Vmu::Pressed(SKU::Vmu::Button button) const {
+    if(auto* s = State(); s)
         return (s->buttons.current.raw & static_cast<unsigned>(button));
 
     return false;
 }
 
-bool SKU::Vmu::tapped(SKU::Vmu::Button button) const {
-    if(auto* s = state(); s)
+bool SKU::Vmu::Tapped(SKU::Vmu::Button button) const {
+    if(auto* s = State(); s)
         return (s->buttons.previous.raw & static_cast<unsigned>(button));
 
     return false;
 }
 
-bool SKU::Vmu::update() const {
-    if(auto* d = dev(); fb.changed && d) {
+bool SKU::Vmu::Update() const {
+    if(auto* d = Dev(); fb.changed && d) {
         vmufb_present(&fb, d);
         fb.changed = false;
         return true;
@@ -83,7 +83,7 @@ bool SKU::Vmu::update() const {
 }
 
 void SKU::KallistiOSInputDevice::UpdateInput() {
-    maple_device_t *device = maple_enum_dev(port(), 0);
+    maple_device_t *device = maple_enum_dev(Port(), 0);
     if(device) {
         active = true;
 
@@ -94,9 +94,9 @@ void SKU::KallistiOSInputDevice::UpdateInput() {
         }
 
         for(unsigned v = 0; v < 2; ++v)
-            vmu[v].update();
+            vmu[v].Update();
 
-        ProcessInput(!port()? CONT_ANY : CONT_P1 + 1);
+        ProcessInput(!Port()? CONT_ANY : CONT_P1 + 1);
     } else {
         active = false;
         gamepadType = DEVICE_TYPE_NONE;
@@ -107,7 +107,7 @@ void SKU::KallistiOSInputDevice::ProcessInput(int32 controllerID) {
     auto& retro = controller[controllerID];
     auto& leftAnalog = stickL[controllerID];
 
-    auto* dev = maple_enum_dev(port(), 0);
+    auto* dev = maple_enum_dev(Port(), 0);
     assert(dev);
 
     switch((gamepadType >> 8)) {
@@ -130,19 +130,19 @@ void SKU::KallistiOSInputDevice::ProcessInput(int32 controllerID) {
             retro.keyA.press |= (state.buttons & CONT_A) != 0;
             retro.keyB.press |= (state.buttons & CONT_B) != 0;
             retro.keyC.press |= (state.buttons & CONT_C) != 0;
-            retro.keyC.press |= (vmu[0].pressed(Vmu::Button::A)
-                              || vmu[1].pressed(Vmu::Button::A));
+            retro.keyC.press |= (vmu[0].Pressed(Vmu::Button::A)
+                              || vmu[1].Pressed(Vmu::Button::A));
 
             retro.keyX.press |= (state.buttons & CONT_X) != 0;
             retro.keyY.press |= (state.buttons & CONT_Y) != 0;
             retro.keyZ.press |= (state.buttons & CONT_Z) != 0;
-            retro.keyZ.press |= (vmu[0].pressed(Vmu::Button::B)
-                              || vmu[1].pressed(Vmu::Button::B));
+            retro.keyZ.press |= (vmu[0].Pressed(Vmu::Button::B)
+                              || vmu[1].Pressed(Vmu::Button::B));
 
             retro.keyStart.press |= (state.buttons & CONT_START) != 0;
             retro.keySelect.press |= (state.buttons & CONT_D) != 0;
-            retro.keySelect.press |= (vmu[0].pressed(Vmu::Button::Mode)
-                                   || vmu[1].pressed(Vmu::Button::Mode));
+            retro.keySelect.press |= (vmu[0].Pressed(Vmu::Button::Mode)
+                                   || vmu[1].Pressed(Vmu::Button::Mode));
             break;
         }
         case DEVICE_TYPE_KEYBOARD: {
@@ -199,7 +199,7 @@ void SKU::InitKallistiOSInputAPI() {
         inputDeviceList[c] = &inputDevices[c];
         inputSlotDevices[c] = &inputDevices[c];
 
-        inputDevices[c].vmu[0].fb.print("***********\n"
+        inputDevices[c].vmu[0].fb.Print("***********\n"
                                         "SONIC MANIA\n"
                                         "***********\n"
                                         "Fuck da PS2!");

--- a/RSDKv5/RSDK/Input/KallistiOS/KallistiOSInputDevice.hpp
+++ b/RSDKv5/RSDK/Input/KallistiOS/KallistiOSInputDevice.hpp
@@ -2,17 +2,72 @@
 #define RSDKV5_KALLISTIOSINPUTDEVICE_H
 
 #include <dc/maple/controller.h>
+#include <dc/maple/vmu.h>
+#include <dc/vmu_fb.h>
 
 namespace SKU
 {
 
+class Vmu {
+private:
+    maple_device_t* dev() const;
+    vmu_state_t* state() const;
+public:
+    struct FrameBuffer: vmufb_t {
+        struct Rect {
+            Rect() {}
+
+            unsigned x = 0;
+            unsigned y = 0;
+            unsigned w = VMU_SCREEN_WIDTH;
+            unsigned h = VMU_SCREEN_HEIGHT;
+        };
+
+        mutable bool changed = false;
+
+        void print(std::string str, unsigned lineSpacing=2, Rect rect=Rect());
+        void blit(const uint8_t* data, Rect rect=Rect());
+        void fill(bool value=true, Rect rect=Rect());
+    } fb;
+
+    enum Button: uint8_t {
+        Up    = VMU_DPAD_UP,
+        Down  = VMU_DPAD_DOWN,
+        Left  = VMU_DPAD_LEFT,
+        Right = VMU_DPAD_RIGHT,
+        A     = VMU_A,
+        B     = VMU_B,
+        Mode  = VMU_MODE,
+        Sleep = VMU_SLEEP
+    };
+
+    const uint8_t port;
+    const uint8_t slot;
+
+    Vmu(uint8_t port_, uint8_t slot_):
+        port(port_), slot(slot_) {}
+
+    bool valid() const;
+    bool update() const;
+    bool beep(uint8_t tone=255, ::std::function<void(void)> task={}) const;
+    bool pressed(Button button) const;
+    bool tapped(Button button) const;
+};
+
 struct KallistiOSInputDevice : InputDevice
 {
+    std::array<Vmu, 2> vmu;
+
+    KallistiOSInputDevice(int port):
+        vmu({ Vmu{ port, 1 }, Vmu{ port, 2 }})
+    {
+        id = port + CONT_P1;
+    }
+
     void UpdateInput() override;
     void ProcessInput(int32 controllerID) override;
     void CloseDevice() override;
-    cont_state_t state {};
-    int32 mapleIndex = 0;
+    int port() const { return id - CONT_P1; }
 };
 
 void InitKallistiOSInputAPI();

--- a/RSDKv5/RSDK/Input/KallistiOS/KallistiOSInputDevice.hpp
+++ b/RSDKv5/RSDK/Input/KallistiOS/KallistiOSInputDevice.hpp
@@ -10,8 +10,8 @@ namespace SKU
 
 class Vmu {
 private:
-    maple_device_t* dev() const;
-    vmu_state_t* state() const;
+    maple_device_t* Dev() const;
+    vmu_state_t* State() const;
 public:
     struct FrameBuffer: vmufb_t {
         struct Rect {
@@ -25,9 +25,9 @@ public:
 
         mutable bool changed = false;
 
-        void print(std::string str, unsigned lineSpacing=2, Rect rect=Rect());
-        void blit(const uint8_t* data, Rect rect=Rect());
-        void fill(bool value=true, Rect rect=Rect());
+        void Print(std::string str, unsigned lineSpacing=2, Rect rect=Rect());
+        void Blit(const uint8_t* data, Rect rect=Rect());
+        void Fill(bool value=true, Rect rect=Rect());
     } fb;
 
     enum Button: uint8_t {
@@ -47,11 +47,11 @@ public:
     Vmu(uint8_t port_, uint8_t slot_):
         port(port_), slot(slot_) {}
 
-    bool valid() const;
-    bool update() const;
-    bool beep(uint8_t tone=255, ::std::function<void(void)> task={}) const;
-    bool pressed(Button button) const;
-    bool tapped(Button button) const;
+    bool Valid() const;
+    bool Update() const;
+    bool Beep(uint8_t tone=255, ::std::function<void(void)> task={}) const;
+    bool Pressed(Button button) const;
+    bool Tapped(Button button) const;
 };
 
 struct KallistiOSInputDevice : InputDevice
@@ -67,7 +67,7 @@ struct KallistiOSInputDevice : InputDevice
     void UpdateInput() override;
     void ProcessInput(int32 controllerID) override;
     void CloseDevice() override;
-    int port() const { return id - CONT_P1; }
+    int Port() const { return id - CONT_P1; }
 };
 
 void InitKallistiOSInputAPI();

--- a/RSDKv5/main.cpp
+++ b/RSDKv5/main.cpp
@@ -79,7 +79,7 @@ int main(int argc, char *argv[]) { return RSDK_main(argc, argv, (void *)LinkGame
 #endif
 
 #if RETRO_PLATFORM == RETRO_KALLISTIOS
-KOS_INIT_FLAGS(INIT_IRQ | INIT_CONTROLLER | INIT_CDROM);
+KOS_INIT_FLAGS(INIT_IRQ | INIT_CONTROLLER | INIT_VMU | INIT_KEYBOARD | INIT_CDROM);
 #endif
 int32 RSDK_main(int32 argc, char **argv, void *linkLogicPtr)
 {
@@ -88,7 +88,7 @@ int32 RSDK_main(int32 argc, char **argv, void *linkLogicPtr)
     gdb_init();
 #endif
     cont_btn_callback(0, CONT_RESET_BUTTONS, [](uint8_t, uint32_t) {
-        exit(EXIT_SUCCESS);
+        arch_abort();
     });
 #endif
 


### PR DESCRIPTION
1) main.cpp
    - Enabled VMU + Keyboard maple drivers
    - Made reset button exit trap abort rather than call exit(), as that seems to hang for jnmartin and me, plus this is faster. 
2) Input Changes

        a. Reduced INPUTDEVICE_COUNT to 4 to save RAM.

        b. Added VMU API
                - Can beep while performing an event for debugging (think while accessing filesystem)
                - VMU Buttons are being polled for extended controller input buttons (Z, D, Select), 
                for people with maple extenders, ASCII pads, or RetroFighters controllers which
                 leave the buttons accessible. 
                - Virtual framebuffers are held within VMUs, allowing you to draw to the screen
                 (text, rects, bitmaps) efficiently. VMU back-end efficiently only sends LCD updates
                  should the FB canvas actaully be read to, to save bandwidth. 

        c. Added keyboard input support 
                - Keyboard button states are now queried and are mapped to the gamepad, allowing
                  it to be used like a controller now to play the game. 
                  
        d. Redid Input API back-end 
                - Rather than dynamically allocating KallistiOSinputDevices on the heap, we statically
                  reserve four of them. 
                - We establish a direct, 1:1 mapping between controller port index and input slot, so
                  that changing devices on a port or removing devices from a port does not dynamically
                  reassign our input slot. 
                - We now support maintaining the gamepadType as NONE, CONTROLLER, or KEYBOARD. 
                - We no longer only check for input devices at startup, when the input system intializes.
                  Instead, we're dynamically checking for presence of input devices or if they've been 
                  removed every time the input device gets updated.