### PR TITLE
Do not clear screen after cutscenes

### DIFF
--- a/RSDKv5/RSDK/Core/RetroEngine.cpp
+++ b/RSDKv5/RSDK/Core/RetroEngine.cpp
@@ -269,13 +269,7 @@ int32 RSDK::RunRetroEngine(int32 argc, char *argv[])
                         case 3: Legacy::v3::ProcessEngine(); break;
                     }
 #else
-#if RETRO_PLATFORM == RETRO_KALLISTIOS
-                    RenderDevice::BeginScene();
                     ProcessEngine();
-                    RenderDevice::EndScene();
-#else
-                    ProcessEngine();
-#endif
 #endif
                 }
 
@@ -516,11 +510,17 @@ void RSDK::ProcessEngine()
             break;
 
         case ENGINESTATE_DEVMENU:
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
+            RenderDevice::BeginScene();
+#endif
             ProcessInput();
             currentScreen = &screens[0];
 
             if (devMenu.state)
                 devMenu.state();
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
+            RenderDevice::EndScene();
+#endif
             break;
 
         case ENGINESTATE_VIDEOPLAYBACK:

--- a/RSDKv5/RSDK/Scene/Object.cpp
+++ b/RSDKv5/RSDK/Scene/Object.cpp
@@ -722,6 +722,9 @@ void RSDK::ProcessFrozenObjects()
 void RSDK::ProcessObjectDrawLists()
 {
     if (sceneInfo.state != ENGINESTATE_LOAD && sceneInfo.state != (ENGINESTATE_LOAD | ENGINESTATE_STEPOVER)) {
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
+        RenderDevice::BeginScene();
+#endif
         for (int32 s = 0; s < videoSettings.screenCount; ++s) {
             currentScreen             = &screens[s];
             sceneInfo.currentScreenID = s;
@@ -1003,6 +1006,9 @@ void RSDK::ProcessObjectDrawLists()
             currentScreen++;
             sceneInfo.currentScreenID++;
         }
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
+        RenderDevice::EndScene();
+#endif
     }
 }
 


### PR DESCRIPTION
This PR removes the jarring screen clear between cutscene and level start.

It accomplishes this by moving the RenderDevice::BeginScene/EndScene calls to a place that is only reached if the current scene state is NOT loading and things are to be drawn.

Also handles the dev menu correctly.