### PR TITLE
Implement AniTile rendering

### DIFF
--- a/RSDKv5/RSDK/Graphics/Drawing.cpp
+++ b/RSDKv5/RSDK/Graphics/Drawing.cpp
@@ -6,6 +6,10 @@ using namespace RSDK;
 #include "Legacy/DrawingLegacy.cpp"
 #endif
 
+#if RETRO_PLATFORM == RETRO_KALLISTIOS && defined(KOS_HARDWARE_RENDERER)
+#include <RSDK/Graphics/KallistiOS/AniTileTracker.hpp>
+#endif
+
 // all render devices need to access the initial vertex buffer :skull:
 
 // clang-format off
@@ -4626,8 +4630,22 @@ void RSDK::DrawTile(uint16 *tiles, int32 countX, int32 countY, Vector2 *position
                         const int32 flip = tile / TILE_COUNT;
                         tile %= TILE_COUNT;
 
-                        const int32 tilesetX = TILE_SIZE * ((int32)tile % KOS_ATLAS_WIDTH_TILES);
-                        const int32 tilesetY = TILE_SIZE * ((int32)tile / KOS_ATLAS_WIDTH_TILES);
+                        int32 sheetID;
+                        int32 tilesetX;
+                        int32 tilesetY;
+
+                        const AniTileState* aniTileState = AniTileTracker::GetAniTile(tile);
+
+                        if (aniTileState != nullptr) {
+                            sheetID = aniTileState->sheetID;
+                            tilesetX = aniTileState->u;
+                            tilesetY = aniTileState->v;
+                        }
+                        else {
+                            sheetID = 0;
+                            tilesetX = TILE_SIZE * (static_cast<int32>(tile) % KOS_ATLAS_WIDTH_TILES);
+                            tilesetY = TILE_SIZE * (static_cast<int32>(tile) / KOS_ATLAS_WIDTH_TILES);
+                        }
 
                         const int32 screenX = (tx * TILE_SIZE) + pivotX;
 
@@ -4637,7 +4655,7 @@ void RSDK::DrawTile(uint16 *tiles, int32 countX, int32 countY, Vector2 *position
                                           flip,
                                           sceneInfo.entity->inkEffect,
                                           sceneInfo.entity->alpha,
-                                          0);
+                                          sheetID);
                     }
                 }
 #else
@@ -4680,8 +4698,22 @@ void RSDK::DrawTile(uint16 *tiles, int32 countX, int32 countY, Vector2 *position
                         int32 flip = tile / TILE_COUNT;
                         tile %= TILE_COUNT;
 
-                        const int32 tilesetX = TILE_SIZE * ((int32)tile % KOS_ATLAS_WIDTH_TILES);
-                        const int32 tilesetY = TILE_SIZE * ((int32)tile / KOS_ATLAS_WIDTH_TILES);
+                        int32 sheetID;
+                        int32 tilesetX;
+                        int32 tilesetY;
+
+                        const AniTileState* aniTileState = AniTileTracker::GetAniTile(tile);
+
+                        if (aniTileState != nullptr) {
+                            sheetID = aniTileState->sheetID;
+                            tilesetX = aniTileState->u;
+                            tilesetY = aniTileState->v;
+                        }
+                        else {
+                            sheetID = 0;
+                            tilesetX = TILE_SIZE * (static_cast<int32>(tile) % KOS_ATLAS_WIDTH_TILES);
+                            tilesetY = TILE_SIZE * (static_cast<int32>(tile) / KOS_ATLAS_WIDTH_TILES);
+                        }
 
                         const int32 screenX = x + (tx * TILE_SIZE);
 
@@ -4701,7 +4733,7 @@ void RSDK::DrawTile(uint16 *tiles, int32 countX, int32 countY, Vector2 *position
                                            static_cast<int16>(rotation),
                                            sceneInfo.entity->inkEffect,
                                            sceneInfo.entity->alpha,
-                                           0);
+                                           sheetID);
                     }
                 }
 #else
@@ -4767,8 +4799,22 @@ void RSDK::DrawTile(uint16 *tiles, int32 countX, int32 countY, Vector2 *position
                         int32 flip = tile / TILE_COUNT;
                         tile %= TILE_COUNT;
 
-                        const int32 tilesetX = TILE_SIZE * ((int32)tile % KOS_ATLAS_WIDTH_TILES);
-                        const int32 tilesetY = TILE_SIZE * ((int32)tile / KOS_ATLAS_WIDTH_TILES);
+                        int32 sheetID;
+                        int32 tilesetX;
+                        int32 tilesetY;
+
+                        const AniTileState* aniTileState = AniTileTracker::GetAniTile(tile);
+
+                        if (aniTileState != nullptr) {
+                            sheetID = aniTileState->sheetID;
+                            tilesetX = aniTileState->u;
+                            tilesetY = aniTileState->v;
+                        }
+                        else {
+                            sheetID = 0;
+                            tilesetX = TILE_SIZE * (static_cast<int32>(tile) % KOS_ATLAS_WIDTH_TILES);
+                            tilesetY = TILE_SIZE * (static_cast<int32>(tile) / KOS_ATLAS_WIDTH_TILES);
+                        }
 
                         const int32 screenX = x + (tx * TILE_SIZE);
                         int32 rotation;
@@ -4789,7 +4835,7 @@ void RSDK::DrawTile(uint16 *tiles, int32 countX, int32 countY, Vector2 *position
                                            static_cast<int16>(rotation),
                                            sceneInfo.entity->inkEffect,
                                            sceneInfo.entity->alpha,
-                                           0);
+                                           sheetID);
                     }
                 }
 #else
@@ -4855,8 +4901,22 @@ void RSDK::DrawTile(uint16 *tiles, int32 countX, int32 countY, Vector2 *position
                         int32 flip = tile / TILE_COUNT;
                         tile %= TILE_COUNT;
 
-                        const int32 tilesetX = TILE_SIZE * ((int32)tile % KOS_ATLAS_WIDTH_TILES);
-                        const int32 tilesetY = TILE_SIZE * ((int32)tile / KOS_ATLAS_WIDTH_TILES);
+                        int32 sheetID;
+                        int32 tilesetX;
+                        int32 tilesetY;
+
+                        const AniTileState* aniTileState = AniTileTracker::GetAniTile(tile);
+
+                        if (aniTileState != nullptr) {
+                            sheetID = aniTileState->sheetID;
+                            tilesetX = aniTileState->u;
+                            tilesetY = aniTileState->v;
+                        }
+                        else {
+                            sheetID = 0;
+                            tilesetX = TILE_SIZE * (static_cast<int32>(tile) % KOS_ATLAS_WIDTH_TILES);
+                            tilesetY = TILE_SIZE * (static_cast<int32>(tile) / KOS_ATLAS_WIDTH_TILES);
+                        }
 
                         const int32 screenX = x + (tx * TILE_SIZE);
                         int32 rotation = sceneInfo.entity->rotation;
@@ -4875,7 +4935,7 @@ void RSDK::DrawTile(uint16 *tiles, int32 countX, int32 countY, Vector2 *position
                                            static_cast<int16>(rotation),
                                            sceneInfo.entity->inkEffect,
                                            sceneInfo.entity->alpha,
-                                           0);
+                                           sheetID);
                     }
                 }
 #else
@@ -4919,7 +4979,7 @@ void RSDK::DrawTile(uint16 *tiles, int32 countX, int32 countY, Vector2 *position
 void RSDK::DrawAniTile(uint16 sheetID, uint16 tileIndex, uint16 srcX, uint16 srcY, uint16 width, uint16 height)
 {
 #if defined(KOS_HARDWARE_RENDERER)
-    // DCTODO: DrawAniTile
+    AniTileTracker::UpdateAniTile(sheetID, tileIndex, srcX, srcY, width, height);
 #else
     if (sheetID < SURFACE_COUNT && tileIndex < TILE_COUNT) {
         GFXSurface *surface = &gfxSurface[sheetID];

--- a/RSDKv5/RSDK/Graphics/KallistiOS/AniTileTracker.cpp
+++ b/RSDKv5/RSDK/Graphics/KallistiOS/AniTileTracker.cpp
@@ -1,0 +1,42 @@
+#include "AniTileTracker.hpp"
+
+using namespace RSDK;
+
+AniTileState AniTileTracker::m_State[TILE_COUNT] {};
+
+// static
+void AniTileTracker::ResetAllTiles() {
+    // could be more efficient
+    for (auto& state : m_State) {
+        state = {};
+    }
+}
+
+// static
+void AniTileTracker::UpdateAniTile(uint16 sheetID, uint16 tileIndex, uint16 u, uint16 v, uint16 width, uint16 height) {
+    if (sheetID >= SURFACE_COUNT || tileIndex >= TILE_COUNT) {
+        return;
+    }
+
+    if ((width % TILE_SIZE) || (height % TILE_SIZE)) {
+        // RUH ROH!!!
+        return;
+    }
+
+    for (uint32 iy = 0; iy < height; iy += TILE_SIZE) {
+        uint16 iu = u;
+
+        for (uint32 ix = 0; ix < width; ix += TILE_SIZE) {
+            assert(tileIndex < TILE_COUNT);
+            auto* state = &m_State[tileIndex++];
+
+            state->sheetID = sheetID;
+            state->u = iu;
+            state->v = v;
+
+            iu += TILE_SIZE;
+        }
+
+        v += TILE_SIZE;
+    }
+}

--- a/RSDKv5/RSDK/Graphics/KallistiOS/AniTileTracker.hpp
+++ b/RSDKv5/RSDK/Graphics/KallistiOS/AniTileTracker.hpp
@@ -1,0 +1,39 @@
+#pragma once
+#include <RSDK/Core/RetroEngine.hpp>
+
+namespace RSDK {
+struct AniTileState {
+    uint16 sheetID = 0;
+    uint16 u = 0;
+    uint16 v = 0;
+
+    [[nodiscard]] bool IsTileAligned() const {
+        return ((u | v) & 0xF) == 0;
+    }
+};
+
+class AniTileTracker {
+public:
+    static void ResetAllTiles();
+    static void UpdateAniTile(uint16 sheetID, uint16 tileIndex, uint16 u, uint16 v, uint16 width, uint16 height);
+    static const AniTileState* GetAniTile(uint16 tileIndex);
+
+private:
+    static AniTileState m_State[TILE_COUNT];
+};
+
+// static
+inline const AniTileState* AniTileTracker::GetAniTile(uint16 tileIndex) {
+    if (tileIndex > TILE_COUNT) {
+        return nullptr;
+    }
+
+    const auto* result = &m_State[tileIndex];
+
+    if (result->sheetID == 0) {
+        return nullptr;
+    }
+
+    return result;
+}
+}  // namespace RSDK

--- a/RSDKv5/RSDK/Graphics/KallistiOS/KallistiOSRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/KallistiOS/KallistiOSRenderDevice.cpp
@@ -883,6 +883,9 @@ void RenderDevice::DrawTexturedQuadPT(
     pvr_dr_commit(reinterpret_cast<uint8_t *>(spr2) + 32);
 }
 
+// DCFIXME: really bad place for this
+struct vec2f { float x; float y; };
+
 // static
 void RenderDevice::DrawTexturedQuadTR(
         int32 x, int32 y,
@@ -945,8 +948,6 @@ void RenderDevice::DrawTexturedQuadPTEx(
     }
 
     lastPrimitiveWasConsumed = true;
-
-    struct vec2f { float x; float y; };
 
     const vec2f upperLeftF {
         static_cast<float>(upperLeft.x) * pixelScaleX,
@@ -1211,6 +1212,96 @@ void RenderDevice::DrawTexturedPolyPT(
         rotate(verts[2]);
         rotate(verts[3]);
     }
+
+    /* This is the routine called by `pvr_prim()` under-the-hood when
+       the current list does not use DMA transfers and PVR DR mode is
+       enabled. We can call this directly to shave off a few cycles. */
+    sq_fast_cpy(SQ_MASK_DEST(PVR_TA_INPUT), verts, 4);
+}
+
+// static
+void RenderDevice::DrawTexturedPolyPTEx(
+    const Vector2& upperLeft, const Vector2& upperRight,
+    const Vector2& lowerLeft, const Vector2& lowerRight,
+    int32 sprX0, int32 sprX1,
+    int32 sprY0, int32 sprY1,
+    const GFXSurface* surface
+) {
+    if (lastPrimitiveType != PrimitiveTypes_TexturedPolyPT) {
+        printf("[pvr] [NG] ATTEMPTED TO DRAW TexturedPolyPT BEFORE PREPPING!\n");
+        return;
+    }
+
+    lastPrimitiveWasConsumed = true;
+
+    // Compute constants up-front
+    const vec2f upperLeftF {
+        static_cast<float>(upperLeft.x) * pixelScaleX,
+        static_cast<float>(upperLeft.y) * pixelScaleY,
+    };
+
+    const vec2f upperRightF {
+        static_cast<float>(upperRight.x) * pixelScaleX,
+        static_cast<float>(upperRight.y) * pixelScaleY,
+    };
+
+    const vec2f lowerLeftF {
+        static_cast<float>(lowerLeft.x) * pixelScaleX,
+        static_cast<float>(lowerLeft.y) * pixelScaleY,
+    };
+
+    const vec2f lowerRightF {
+        static_cast<float>(lowerRight.x) * pixelScaleX,
+        static_cast<float>(lowerRight.y) * pixelScaleY,
+    };
+
+    const float z  = GetDepth();
+    const float u0 = shz_div_posf(sprX0, surface->width);
+    const float v0 = shz_div_posf(sprY0, surface->height);
+    const float u1 = shz_div_posf(sprX1, surface->width);
+    const float v1 = shz_div_posf(sprY1, surface->height);
+
+    /* Since we have to potentially modify the vertex stream later on to apply
+       rotation to it, we're better off constructing it in RAM rather than
+       using the PVR DR API to write to the SQs directly. SQs are read-only! */
+    pvr_vertex_t verts[4] = {
+        {
+            .flags = PVR_CMD_VERTEX,
+            .x = upperLeftF.x,
+            .y = upperLeftF.y,
+            .z = z,
+            .u = u0,
+            .v = v0,
+            .argb = 0xFFFFFFFFu
+        },
+        {
+            .flags = PVR_CMD_VERTEX,
+            .x = upperRightF.x,
+            .y = upperRightF.y,
+            .z = z,
+            .u = u1,
+            .v = v0,
+            .argb = 0xFFFFFFFFu
+        },
+        {
+            .flags = PVR_CMD_VERTEX,
+            .x = lowerLeftF.x,
+            .y = lowerLeftF.y,
+            .z = z,
+            .u = u0,
+            .v = v1,
+            .argb = 0xFFFFFFFFu
+        },
+        {
+            .flags = PVR_CMD_VERTEX_EOL,
+            .x = lowerRightF.x,
+            .y = lowerRightF.y,
+            .z = z,
+            .u = u1,
+            .v = v1,
+            .argb = 0xFFFFFFFFu
+        }
+    };
 
     /* This is the routine called by `pvr_prim()` under-the-hood when
        the current list does not use DMA transfers and PVR DR mode is

--- a/RSDKv5/RSDK/Graphics/KallistiOS/KallistiOSRenderDevice.hpp
+++ b/RSDKv5/RSDK/Graphics/KallistiOS/KallistiOSRenderDevice.hpp
@@ -99,6 +99,13 @@ public:
             int32 alpha,
             const GFXSurface *surface
     );
+    static void DrawTexturedPolyPTEx(
+        const Vector2& upperLeft, const Vector2& upperRight,
+        const Vector2& lowerLeft, const Vector2& lowerRight,
+        int32 sprX0, int32 sprX1,
+        int32 sprY0, int32 sprY1,
+        const GFXSurface* surface
+    );
 
     static void PrepareTexturedPolyTR(int32 y, int inkEffect, const GFXSurface* surface);
     static void DrawTexturedPolyTR(

--- a/RSDKv5/RSDK/Scene/Scene.cpp
+++ b/RSDKv5/RSDK/Scene/Scene.cpp
@@ -1,5 +1,9 @@
 #include "RSDK/Core/RetroEngine.hpp"
 
+#ifdef KOS_HARDWARE_RENDERER
+#include <RSDK/Graphics/KallistiOS/AniTileTracker.hpp>
+#endif
+
 using namespace RSDK;
 
 #if RETRO_REV0U
@@ -274,6 +278,10 @@ void RSDK::LoadSceneFolder()
 
         CloseFile(&info);
     }
+
+#ifdef KOS_HARDWARE_RENDERER
+    AniTileTracker::ResetAllTiles();
+#endif
 
     sprintf_s(fullFilePath, sizeof(fullFilePath), "Data/Stages/%s/16x16Tiles.gif", currentSceneFolder);
     LoadStageGIF(fullFilePath);
@@ -1425,13 +1433,36 @@ void DrawByLayout(uint16 layout, int32 screenX, int32 screenY) {
     const int32 flip = layout / TILE_COUNT;
     layout %= TILE_COUNT;
 
-    const int32 tilesetX = TILE_SIZE * ((int32)layout % KOS_ATLAS_WIDTH_TILES);
-    const int32 tilesetY = TILE_SIZE * ((int32)layout / KOS_ATLAS_WIDTH_TILES);
+    bool usePoly;
+    const GFXSurface* surface;
+    const AniTileState* aniTileState = AniTileTracker::GetAniTile(layout);
 
-    int32 sprX0 = tilesetX;
-    int32 sprX1 = tilesetX;
-    int32 sprY0 = tilesetY;
-    int32 sprY1 = tilesetY;
+    int32 sprX0;
+    int32 sprX1;
+    int32 sprY0;
+    int32 sprY1;
+
+    if (aniTileState != nullptr && aniTileState->sheetID != 0) {
+        usePoly = !aniTileState->IsTileAligned();
+        surface = &gfxSurface[aniTileState->sheetID];
+
+        sprX0 = aniTileState->u;
+        sprX1 = aniTileState->u;
+        sprY0 = aniTileState->v;
+        sprY1 = aniTileState->v;
+    }
+    else {
+        usePoly = false;
+        surface = &gfxSurface[0];
+
+        const int32 tilesetX = TILE_SIZE * (static_cast<int32>(layout) % KOS_ATLAS_WIDTH_TILES);
+        const int32 tilesetY = TILE_SIZE * (static_cast<int32>(layout) / KOS_ATLAS_WIDTH_TILES);
+
+        sprX0 = tilesetX;
+        sprX1 = tilesetX;
+        sprY0 = tilesetY;
+        sprY1 = tilesetY;
+    }
 
     if (flip & FLIP_X) {
         sprX0 += TILE_SIZE;
@@ -1447,13 +1478,33 @@ void DrawByLayout(uint16 layout, int32 screenX, int32 screenY) {
         sprY1 += TILE_SIZE;
     }
 
-    RenderDevice::DrawTexturedQuadPT(
-        screenX, screenY,
-        TILE_SIZE, TILE_SIZE,
-        sprX0, sprX1,
-        sprY0, sprY1,
-        &gfxSurface[0]
-    );
+    const int32 prepY = std::max<int32>(0, screenY);
+
+    if (usePoly) {
+        RenderDevice::PrepareTexturedPolyPT(prepY, INK_NONE, surface);
+
+        RenderDevice::DrawTexturedPolyPT(
+            screenX, screenY,
+            screenX, screenY,
+            TILE_SIZE, TILE_SIZE,
+            sprX0, sprX1,
+            sprY0, sprY1,
+            0,
+            255,
+            surface
+        );
+    }
+    else {
+        RenderDevice::PrepareTexturedQuadPT(prepY, surface);
+
+        RenderDevice::DrawTexturedQuadPT(
+            screenX, screenY,
+            TILE_SIZE, TILE_SIZE,
+            sprX0, sprX1,
+            sprY0, sprY1,
+            &gfxSurface[0]
+        );
+    }
 }
 
 void DrawByLayoutEx(uint16 layout,
@@ -1463,13 +1514,36 @@ void DrawByLayoutEx(uint16 layout,
     const int32 flip = layout / TILE_COUNT;
     layout %= TILE_COUNT;
 
-    const int32 tilesetX = TILE_SIZE * (static_cast<int32>(layout) % KOS_ATLAS_WIDTH_TILES);
-    const int32 tilesetY = TILE_SIZE * (static_cast<int32>(layout) / KOS_ATLAS_WIDTH_TILES);
+    bool usePoly;
+    const GFXSurface* surface;
+    const AniTileState* aniTileState = AniTileTracker::GetAniTile(layout);
 
-    int32 sprX0 = tilesetX;
-    int32 sprX1 = tilesetX;
-    int32 sprY0 = tilesetY;
-    int32 sprY1 = tilesetY;
+    int32 sprX0;
+    int32 sprX1;
+    int32 sprY0;
+    int32 sprY1;
+
+    if (aniTileState != nullptr && aniTileState->sheetID != 0) {
+        usePoly = !aniTileState->IsTileAligned();
+        surface = &gfxSurface[aniTileState->sheetID];
+
+        sprX0 = aniTileState->u;
+        sprX1 = aniTileState->u;
+        sprY0 = aniTileState->v;
+        sprY1 = aniTileState->v;
+    }
+    else {
+        usePoly = false;
+        surface = &gfxSurface[0];
+
+        const int32 tilesetX = TILE_SIZE * (static_cast<int32>(layout) % KOS_ATLAS_WIDTH_TILES);
+        const int32 tilesetY = TILE_SIZE * (static_cast<int32>(layout) / KOS_ATLAS_WIDTH_TILES);
+
+        sprX0 = tilesetX;
+        sprX1 = tilesetX;
+        sprY0 = tilesetY;
+        sprY1 = tilesetY;
+    }
 
     if (flip & FLIP_X) {
         sprX0 += TILE_SIZE;
@@ -1485,13 +1559,29 @@ void DrawByLayoutEx(uint16 layout,
         sprY1 += TILE_SIZE;
     }
 
-    RenderDevice::DrawTexturedQuadPTEx(
-        upperLeft, upperRight,
-        lowerLeft, lowerRight,
-        sprX0, sprX1,
-        sprY0, sprY1,
-        &gfxSurface[0]
-    );
+    const int32 prepY = std::max<int32>(0, std::min(upperLeft.y, upperRight.y));
+
+    if (usePoly) {
+        RenderDevice::PrepareTexturedPolyPT(prepY, INK_NONE, surface);
+
+        RenderDevice::DrawTexturedPolyPTEx(
+            upperLeft, upperRight,
+            lowerLeft, lowerRight,
+            sprX0, sprX1,
+            sprY0, sprY1,
+            surface);
+    }
+    else {
+        RenderDevice::PrepareTexturedQuadPT(prepY, surface);
+
+        RenderDevice::DrawTexturedQuadPTEx(
+            upperLeft, upperRight,
+            lowerLeft, lowerRight,
+            sprX0, sprX1,
+            sprY0, sprY1,
+            surface
+        );
+    }
 }
 
 int32 GetLayerWrappedFromFixedX(const TileLayer* layer, int32 fixed_x) {
@@ -1515,9 +1605,6 @@ void RSDK::DrawLayerHScroll(TileLayer *layer)
 
 #if defined(KOS_HARDWARE_RENDERER)
     const ScanlineInfo* upperScanline = &scanlines[currentScreen->clipBound_Y1];
-
-    const int32 prepY = currentScreen->clipBound_Y1;
-    const GFXSurface* prepSurface = &gfxSurface[0];
 
     const int32 sheetY = FROM_FIXED(upperScanline->position.y) & 0xF;
     int32 scanlineIncrement = TILE_SIZE - sheetY;
@@ -1567,8 +1654,6 @@ void RSDK::DrawLayerHScroll(TileLayer *layer)
             if (layout == 0xFFFF) {
                 continue;
             }
-
-            RenderDevice::PrepareTexturedQuadPT(prepY, prepSurface);
 
             const Vector2 screenUpperLeft {
                 screenUpperX,
@@ -1956,9 +2041,6 @@ void RSDK::DrawLayerBasic(TileLayer *layer)
     uint16 *activePalette = fullPalette[0];
     if (currentScreen->clipBound_X1 < currentScreen->clipBound_X2 && currentScreen->clipBound_Y1 < currentScreen->clipBound_Y2) {
 #if RETRO_PLATFORM == RETRO_KALLISTIOS
-        const int32 prepY = currentScreen->clipBound_Y1;
-        const auto* prepSurface = &gfxSurface[0];
-
         ScanlineInfo *scanline = &scanlines[currentScreen->clipBound_Y1];
 
         int32 ty = FROM_FIXED(scanline->position.y) >> 4;
@@ -1974,7 +2056,6 @@ void RSDK::DrawLayerBasic(TileLayer *layer)
 
             for (int32 screenX = currentScreen->clipBound_X1 - offsetX; screenX < currentScreen->clipBound_X2; screenX += TILE_SIZE) {
                 if (*layout != 0xFFFF) {
-                    RenderDevice::PrepareTexturedQuadPT(prepY, prepSurface);
                     DrawByLayout(*layout, screenX, screenY);
                 }
 

--- a/platforms/KallistiOS.cmake
+++ b/platforms/KallistiOS.cmake
@@ -1,5 +1,7 @@
 project(RetroEngine)
 
+set(RETRO_FILES ${RETRO_FILES} RSDKv5/RSDK/Graphics/KallistiOS/AniTileTracker.cpp)
+
 add_executable(RetroEngine ${RETRO_FILES})
 
 if(NOT GAME_STATIC)

--- a/platforms/KallistiOS.cmake
+++ b/platforms/KallistiOS.cmake
@@ -1,8 +1,6 @@
-project(RetroEngine)
-
-set(RETRO_FILES ${RETRO_FILES} RSDKv5/RSDK/Graphics/KallistiOS/AniTileTracker.cpp)
-
-add_executable(RetroEngine ${RETRO_FILES})
+add_executable(RetroEngine ${RETRO_FILES}
+    RSDKv5/RSDK/Graphics/KallistiOS/AniTileTracker.cpp
+)
 
 if(NOT GAME_STATIC)
     message(FATAL_ERROR "GAME_STATIC must be on")


### PR DESCRIPTION
This PR implements AniTile (animated tile) rendering by swapping textures before drawing tile layouts (whereas the original implementation copies animated tiles into the main tile set before rendering). Here's a little overview:

- Added `AniTileTracker` class to track update requests for tiles which flags tiles by index for animation and points to the `GFXSurface` to sample from in place of the main tile set
- `RenderDevice::DrawTexturedPolyPTEx` function is introduced which:
  1. Handles cases where AniTile textures require non-16px aligned UV coordinates which are incompatible with quads
  2. Still enables tile skewing like with quads

New source files were added using `platforms/KallistiOS.cmake`. Hoping for @gyrovorbis's thoughts on this. Bad idea? Acceptable?

Note: Sonic Mania will need a patch to fix certain AniTiles in Flying Battery. This implementation requires AniTile "updates" to align to 16px boundaries, and Flying Battery is the only stage that doesn't meet this requirement. It would appear to be arbitrary though - it's only off by 2 vertical pixels and is easily adjusted without negatively affecting the rendered output. I believe this discrepancy was just to avoid copying a couple rows, but for us that's not a concern.