### PR TITLE
working "is stream playing" check

### DIFF
--- a/RSDKv5/RSDK/Audio/Audio.hpp
+++ b/RSDKv5/RSDK/Audio/Audio.hpp
@@ -211,12 +211,23 @@ inline bool32 SfxPlaying(uint16 sfx)
     return false;
 }
 
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
+extern "C" {
+    int stream_is_playing(void);
+}
+#endif
+
 inline bool32 ChannelActive(uint32 channel)
 {
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
+    // afaict only used to check if song still playing in credits scroll
+    return stream_is_playing();
+#else
     if (channel >= CHANNEL_COUNT)
         return false;
     else
         return (channels[channel].state & 0x3F) != CHANNEL_IDLE;
+#endif
 }
 
 uint32 GetChannelPos(uint32 channel);

--- a/RSDKv5/RSDK/Audio/KallistiOS/KallistiOSStream.cpp
+++ b/RSDKv5/RSDK/Audio/KallistiOS/KallistiOSStream.cpp
@@ -254,7 +254,7 @@ void stream_volume(int vol)
 
 int stream_is_playing(void)
 {
-    return stream.status == SNDDEC_STATUS_STREAMING;
+    return (stream.status == SNDDEC_STATUS_STREAMING) || (stream.status == SNDDEC_STATUS_RESUMING);
 }
 
 static void *sndstream_thread(void *param)


### PR DESCRIPTION
This fixes the weird behavior in end credits where all of the songs play for a fraction of a second, stop and move to the next.