### PR TITLE
fix STR pool OOM in credits sequence

### DIFF
--- a/RSDKv5/RSDK/Storage/Storage.cpp
+++ b/RSDKv5/RSDK/Storage/Storage.cpp
@@ -88,9 +88,9 @@ bool32 RSDK::InitStorage()
 #if RETRO_PLATFORM == RETRO_KALLISTIOS  /* SAYGA DREAMCAST: Where Sonic Belongs! */
                                                                        // RAM: 32  / 16  MB
                                                                        // -----------------
-    dataStorage[DATASET_STG].storageLimit = 400000 + (DBL_MEM? 4 : 4) * 1024 * 1024; // 4   / 4   MB
-    dataStorage[DATASET_STR].storageLimit = (DBL_MEM? 2 : 2) *  32 * 1024; // 64  / 32  KB
-    dataStorage[DATASET_TMP].storageLimit = 100000 + (DBL_MEM? 6 : 3) * 1024 * 1024; // 6   / 3   MB
+    dataStorage[DATASET_STG].storageLimit = 400000 + (DBL_MEM? 4 : 4) * 1024 * 1024; // 4.4   / 4.4   MB
+    dataStorage[DATASET_STR].storageLimit = (DBL_MEM? 3 : 3) *  32 * 1024; // 96  / 96  KB
+    dataStorage[DATASET_TMP].storageLimit = 100000 + (DBL_MEM? 6 : 3) * 1024 * 1024; // 6.1   / 3.1   MB
                                                                      //   -----------------
 #else                                                                // Total: 16+ / 7+  MB 
                                         /* PCs AND BORING SHIT */


### PR DESCRIPTION
There are a bunch of small failed allocations in the String pool when the Credits sequence is being prepared.

This leads to glitched output and potentially crashing during the credits.

This fix provides a small bump to the STG pool size, enough to make all of the allocations succeed.