### PR TITLE
minor RETRO_KALLISTIOS refactor

### DIFF
--- a/RSDKv5/RSDK/Audio/Audio.cpp
+++ b/RSDKv5/RSDK/Audio/Audio.cpp
@@ -3,7 +3,6 @@
 using namespace RSDK;
 
 #if RETRO_PLATFORM == RETRO_KALLISTIOS
-extern RetroEngine RSDK::engine;
 #include <RSDK/Core/Stub.hpp>
 #endif
 
@@ -11,11 +10,11 @@ extern RetroEngine RSDK::engine;
 #include "Legacy/AudioLegacy.cpp"
 #endif
 
+#if RETRO_PLATFORM != RETRO_KALLISTIOS
 #define STB_VORBIS_NO_PUSHDATA_API
 #define STB_VORBIS_NO_STDIO
 #define STB_VORBIS_NO_INTEGER_CONVERSION
 
-#if RETRO_PLATFORM != RETRO_KALLISTIOS
 #include "stb_vorbis/stb_vorbis.c"
 
 stb_vorbis *vorbisInfo = NULL;


### PR DESCRIPTION
move some VORBIS related defines into a != KALLISTIOS block, and remove redundant extern ::engine from a == KALLISTIOS block