### PR TITLE
Lower EntityBase max reserved size

### DIFF
--- a/RSDKv5/RSDK/Scene/Object.cpp
+++ b/RSDKv5/RSDK/Scene/Object.cpp
@@ -91,7 +91,7 @@ void RSDK::RegisterObject(Object **staticVars, const char *name, uint32 entityCl
         classInfo->staticLoad = staticLoad;
 #endif
 
-#if !RETRO_USE_ORIGINAL_CODE
+#if !RETRO_USE_ORIGINAL_CODE && RETRO_PLATFORM != RETRO_KALLISTIOS
         classInfo->name = name;
 #endif
 

--- a/RSDKv5/RSDK/Scene/Object.hpp
+++ b/RSDKv5/RSDK/Scene/Object.hpp
@@ -137,7 +137,11 @@ struct Entity {
 };
 
 struct EntityBase : Entity {
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
+    void *data[0xF2];
+#else
     void *data[0x100];
+#endif
 #if RETRO_REV0U
     void *unknown;
 #endif

--- a/RSDKv5/RSDK/Scene/Object.hpp
+++ b/RSDKv5/RSDK/Scene/Object.hpp
@@ -10,7 +10,11 @@ namespace RSDK
 
 #define RSDK_SIGNATURE_OBJ (0x4A424F) // "OBJ"
 
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
+#define OBJECT_COUNT (605) // 603 Mania objects + 2 Engine objects
+#else
 #define OBJECT_COUNT (0x400)
+#endif
 
 // 0x800 scene objects, 0x40 reserved ones, and 0x100 spare slots for creation
 #define RESERVE_ENTITY_COUNT (0x40)
@@ -188,7 +192,7 @@ struct ObjectClass {
     ObjectClass *inherited;
 #endif
 
-#if !RETRO_USE_ORIGINAL_CODE
+#if !RETRO_USE_ORIGINAL_CODE && RETRO_PLATFORM != RETRO_KALLISTIOS
     const char *name; // for debugging purposes
 #endif
 };

--- a/RSDKv5/RSDK/Scene/Objects/DevOutput.hpp
+++ b/RSDKv5/RSDK/Scene/Objects/DevOutput.hpp
@@ -22,7 +22,11 @@ struct EntityDevOutput : Entity {
     int32 state;
     int32 timer;
     int32 ySize;
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
+    char message[256];
+#else
     char message[1012];
+#endif
 };
 
 // Object Entity


### PR DESCRIPTION
The DevOutput entity is mostly unused and takes up all the EntityBase reserved size, reduce the `message` field to save on space. The biggest Entity struct in Mania is EntityUICreditsText (1056 bytes). We can safely lower the max reserved size to reach that cap and save up to ~129KiB.