### PR TITLE
fix assert failure in `snd_stream_stop`

### DIFF
--- a/RSDKv5/RSDK/Audio/KallistiOS/KallistiOSStream.cpp
+++ b/RSDKv5/RSDK/Audio/KallistiOS/KallistiOSStream.cpp
@@ -265,27 +265,38 @@ static void *sndstream_thread(void *param)
     while (sndstream_status != SNDDRV_STATUS_DONE) {
         mutex_lock(&stream_mutex);
 
+
         switch (stream.status) {
         case SNDDEC_STATUS_RESUMING:
-            snd_stream_volume(stream.shnd, stream.vol);
-            snd_stream_start_pcm8(stream.shnd, STREAM_SAMPLE_RATE, STREAM_CHANNELS - 1);
-            snd_stream_volume(stream.shnd, stream.vol);
-            stream.status = SNDDEC_STATUS_STREAMING;
+            if (stream.shnd != SND_STREAM_INVALID) {
+                snd_stream_volume(stream.shnd, stream.vol);
+                snd_stream_start_pcm8(stream.shnd, STREAM_SAMPLE_RATE, STREAM_CHANNELS - 1);
+                snd_stream_volume(stream.shnd, stream.vol);
+                stream.status = SNDDEC_STATUS_STREAMING;
+            } else {
+                stream.status = SNDDEC_STATUS_READY;
+            }
             break;
         case SNDDEC_STATUS_PAUSING:
-            snd_stream_stop(stream.shnd);
+            if (stream.shnd != SND_STREAM_INVALID) {
+                snd_stream_stop(stream.shnd);
+            }
             stream.status = SNDDEC_STATUS_READY;
             break;
         case SNDDEC_STATUS_STOPPING:
-            snd_stream_stop(stream.shnd);
-            if (stream.stream_file != NULL) {
-                // ok if this fails, we are stopping anyway
-                fSeek(stream.stream_file, 0, SEEK_SET);
+            if (stream.shnd != SND_STREAM_INVALID) {
+                snd_stream_stop(stream.shnd);
+                if (stream.stream_file != NULL) {
+                    // ok if this fails, we are stopping anyway
+                    fSeek(stream.stream_file, 0, SEEK_SET);
+                }
             }
             stream.status = SNDDEC_STATUS_READY;
             break;
         case SNDDEC_STATUS_STREAMING:
-            snd_stream_poll(stream.shnd);
+            if (stream.shnd != SND_STREAM_INVALID) {
+                snd_stream_poll(stream.shnd);
+            }
             break;
         case SNDDEC_STATUS_READY:
         default:
@@ -306,13 +317,17 @@ static void *stream_file_callback(snd_stream_hnd_t hnd, int req, int *done)
 
     if (read != req) {
         if (fError(stream.stream_file)) {
-            snd_stream_stop(stream.shnd);
+            if (stream.shnd != SND_STREAM_INVALID) {
+                snd_stream_stop(stream.shnd);
+            }
             stream.status = SNDDEC_STATUS_READY;
             return NULL;
         } else if (stream.loop) {
             int seek1 = fSeek(stream.stream_file, (off_t)stream.loop, SEEK_SET);
             if (seek1 != 0) {
-                snd_stream_stop(stream.shnd);
+                if (stream.shnd != SND_STREAM_INVALID) {
+                    snd_stream_stop(stream.shnd);
+                }
                 stream.status = SNDDEC_STATUS_READY;
                 return NULL;
             }
@@ -320,12 +335,16 @@ static void *stream_file_callback(snd_stream_hnd_t hnd, int req, int *done)
             size_t read2 = fRead(stream.drv_buf + read, 1, req - read, stream.stream_file);
 
             if (read2 != (req - read)) {
-                snd_stream_stop(stream.shnd);
+                if (stream.shnd != SND_STREAM_INVALID) {
+                    snd_stream_stop(stream.shnd);
+                }
                 stream.status = SNDDEC_STATUS_READY;
                 return NULL;
             }
         } else {
-            snd_stream_stop(stream.shnd);
+            if (stream.shnd != SND_STREAM_INVALID) {
+                snd_stream_stop(stream.shnd);
+            }
             stream.status = SNDDEC_STATUS_READY;
             return NULL;
         }

--- a/RSDKv5/RSDK/Graphics/KallistiOS/mpeg.c
+++ b/RSDKv5/RSDK/Graphics/KallistiOS/mpeg.c
@@ -89,8 +89,10 @@ static inline void sound_stream_reset(mpeg_player_t *player) {
     if (!player)
         return;
 
-    if (player->start_time != 0)
-        snd_stream_stop(player->snd_hnd);
+    if (player->start_time != 0) {
+        if (player->snd_hnd != SND_STREAM_INVALID)
+            snd_stream_stop(player->snd_hnd);
+    }
 
     player->snd_mod_size = 0;
     player->snd_mod_start = 0;

--- a/dreamcast/gfx_step_1_toalphapng.sh
+++ b/dreamcast/gfx_step_1_toalphapng.sh
@@ -11,13 +11,11 @@ stage=$1
 
 # ImageMagick compatibility (IM7: magick, IM6: convert/identify)
 if command -v magick >/dev/null 2>&1; then
-  IM_IDENTIFY=(magick identify)
   IM_CONVERT=(magick)
 elif command -v convert >/dev/null 2>&1 && command -v identify >/dev/null 2>&1; then
-  IM_IDENTIFY=(identify)
   IM_CONVERT=(convert)
 else
-  die "ImageMagick not found (need magick or convert+identify)"
+  die "ImageMagick not found (need magick or convert)"
 fi
 
 orig_dir=$(pwd -P)
@@ -27,32 +25,17 @@ trap restore_dir EXIT
 cd -- "$stage/Sprites"
 shopt -s nullglob
 
-get_palette0_hex() {
-  # Extract palette entry 0 as "#RRGGBB" from the first frame of a GIF.
-  local gif=$1
-  LC_ALL=C "${IM_IDENTIFY[@]}" -verbose "${gif}[0]" |
-    awk '
-      $1=="Colormap:" {inmap=1; next}
-      inmap && $1=="0:" {
-        for (i=1;i<=NF;i++)
-          if ($i ~ /^#[0-9A-Fa-f]{6}/) { print substr($i,1,7); exit }
-      }
-    '
-}
-
 for dir in Global TMZ1 UI; do
   [[ -d "$dir" ]] || die "missing sprites subdir: $PWD/$dir"
 
   for file in "$dir"/*.gif "$dir"/*.GIF; do
     base=${file%.[gG][iI][fF]}
 
-    palette0=$(get_palette0_hex "$file" || true)
-    [[ -n "$palette0" ]] || die "could not extract palette entry 0 from: $file"
-
     # Convert: palette0 becomes transparent, output RGBA PNG
     "${IM_CONVERT[@]}" "$file" \
       -alpha on \
-      -transparent "$palette0" \
+      -transparent "#FF00FF" \
+      -transparent "#00FF00" \
       -define png:color-type=6 \
       "$base.png"
   done


### PR DESCRIPTION
I had not done a build with assert-enabled KOS in quite some time. There were issues with the unsafe way I was calling `snd_stream_stop`. Those issues are resolved with this PR.