### PR TITLE
fix unsafe calls to "snd_stream_stop"

### DIFF
--- a/RSDKv5/RSDK/Audio/KallistiOS/KallistiOSStream.cpp
+++ b/RSDKv5/RSDK/Audio/KallistiOS/KallistiOSStream.cpp
@@ -267,25 +267,35 @@ static void *sndstream_thread(void *param)
 
         switch (stream.status) {
         case SNDDEC_STATUS_RESUMING:
-            snd_stream_volume(stream.shnd, stream.vol);
-            snd_stream_start_pcm8(stream.shnd, STREAM_SAMPLE_RATE, STREAM_CHANNELS - 1);
-            snd_stream_volume(stream.shnd, stream.vol);
-            stream.status = SNDDEC_STATUS_STREAMING;
+            if (stream.shnd != SND_STREAM_INVALID) {
+                snd_stream_volume(stream.shnd, stream.vol);
+                snd_stream_start_pcm8(stream.shnd, STREAM_SAMPLE_RATE, STREAM_CHANNELS - 1);
+                snd_stream_volume(stream.shnd, stream.vol);
+                stream.status = SNDDEC_STATUS_STREAMING;
+            } else {
+                stream.status = SNDDEC_STATUS_READY;
+            }
             break;
         case SNDDEC_STATUS_PAUSING:
-            snd_stream_stop(stream.shnd);
+            if (stream.shnd != SND_STREAM_INVALID) {
+                snd_stream_stop(stream.shnd);
+            }
             stream.status = SNDDEC_STATUS_READY;
             break;
         case SNDDEC_STATUS_STOPPING:
-            snd_stream_stop(stream.shnd);
-            if (stream.stream_file != NULL) {
-                // ok if this fails, we are stopping anyway
-                fSeek(stream.stream_file, 0, SEEK_SET);
+            if (stream.shnd != SND_STREAM_INVALID) {
+                snd_stream_stop(stream.shnd);
+                if (stream.stream_file != NULL) {
+                    // ok if this fails, we are stopping anyway
+                    fSeek(stream.stream_file, 0, SEEK_SET);
+                }
             }
             stream.status = SNDDEC_STATUS_READY;
             break;
         case SNDDEC_STATUS_STREAMING:
-            snd_stream_poll(stream.shnd);
+            if (stream.shnd != SND_STREAM_INVALID) {
+                snd_stream_poll(stream.shnd);
+            }
             break;
         case SNDDEC_STATUS_READY:
         default:
@@ -306,13 +316,17 @@ static void *stream_file_callback(snd_stream_hnd_t hnd, int req, int *done)
 
     if (read != req) {
         if (fError(stream.stream_file)) {
-            snd_stream_stop(stream.shnd);
+            if (stream.shnd != SND_STREAM_INVALID) {
+                snd_stream_stop(stream.shnd);
+            }
             stream.status = SNDDEC_STATUS_READY;
             return NULL;
         } else if (stream.loop) {
             int seek1 = fSeek(stream.stream_file, (off_t)stream.loop, SEEK_SET);
             if (seek1 != 0) {
-                snd_stream_stop(stream.shnd);
+                if (stream.shnd != SND_STREAM_INVALID) {
+                    snd_stream_stop(stream.shnd);
+                }
                 stream.status = SNDDEC_STATUS_READY;
                 return NULL;
             }
@@ -320,12 +334,16 @@ static void *stream_file_callback(snd_stream_hnd_t hnd, int req, int *done)
             size_t read2 = fRead(stream.drv_buf + read, 1, req - read, stream.stream_file);
 
             if (read2 != (req - read)) {
-                snd_stream_stop(stream.shnd);
+                if (stream.shnd != SND_STREAM_INVALID) {
+                    snd_stream_stop(stream.shnd);
+                }
                 stream.status = SNDDEC_STATUS_READY;
                 return NULL;
             }
         } else {
-            snd_stream_stop(stream.shnd);
+            if (stream.shnd != SND_STREAM_INVALID) {
+                snd_stream_stop(stream.shnd);
+            }
             stream.status = SNDDEC_STATUS_READY;
             return NULL;
         }

--- a/RSDKv5/RSDK/Graphics/KallistiOS/mpeg.c
+++ b/RSDKv5/RSDK/Graphics/KallistiOS/mpeg.c
@@ -89,8 +89,10 @@ static inline void sound_stream_reset(mpeg_player_t *player) {
     if (!player)
         return;
 
-    if (player->start_time != 0)
-        snd_stream_stop(player->snd_hnd);
+    if (player->start_time != 0) {
+        if (player->snd_hnd != SND_STREAM_INVALID)
+            snd_stream_stop(player->snd_hnd);
+    }
 
     player->snd_mod_size = 0;
     player->snd_mod_start = 0;


### PR DESCRIPTION
I had not done an assert-enabled build of KOS for some time. I did not realize there was an assert failure because of the unsafe way I called `snd_stream_stop` without chechking the handle value first. This PR resolves that issue.