### PR TITLE
release LOD texture when loading new scenes

### DIFF
--- a/RSDKv5/RSDK/Scene/Scene.cpp
+++ b/RSDKv5/RSDK/Scene/Scene.cpp
@@ -2277,7 +2277,7 @@ void RSDK::DrawLayerVScroll(TileLayer *layer)
 #define recip1k 0.00097656f
 
 void rayIntersect(Vector4f cam, Vector4f forward, Vector4f right, Vector4f up, int screenX, int screenY, float *hitX, float *hitZ) {
-    float px = (float)screenX - ((float)320*0.5f);
+    float px = (float)screenX - ((float)DEFAULT_PIXWIDTH*0.5f);
     float py = 120.0f - (float)screenY;
     float nx = px * recip200;
     float ny = py * recip200;
@@ -2381,7 +2381,7 @@ void RSDK::DrawLayerRotozoom(TileLayer *layer)
     float dfc = fipr(forward.x, forward.y, forward.z, 0, cam.x, cam.y, cam.z, 0);
 
     // leaving this here to show how f and foa were derived
-    const float aspect = (float)320 / 240.0f;
+    const float aspect = (float)DEFAULT_PIXWIDTH / 240.0f;
     const float fovy   = 47.5f * RSDK_PI / 180.0f;
     const float f      = 1.0f / tanf(fovy * 0.5f);
     const float foa    = f / aspect;
@@ -2396,10 +2396,10 @@ void RSDK::DrawLayerRotozoom(TileLayer *layer)
 
     // ndc to screenspace matrix
     const float __attribute__((aligned(32))) screenspace[4][4] = {
-        {  ((float)320*0.5f),    0.0f, 0.0f, 0.0f },
+        {  ((float)DEFAULT_PIXWIDTH*0.5f),    0.0f, 0.0f, 0.0f },
         {                            0.0f, -120.0f, 0.0f, 0.0f, },
         {                            0.0f,    0.0f, 0.5f, 0.0f, },
-        {  ((float)320*0.5f),  120.0f, 0.5f, 1.0f, },
+        {  ((float)DEFAULT_PIXWIDTH*0.5f),  120.0f, 0.5f, 1.0f, },
     };
 
     // store result of load/apply to use for early-out -w test

--- a/RSDKv5/RSDK/Scene/Scene.cpp
+++ b/RSDKv5/RSDK/Scene/Scene.cpp
@@ -61,9 +61,6 @@ static int ufoNum = 0;
 static bool lodTextureReady = false;
 static int lodTexWidth = 0;
 static int lodTexHeight = 0;
-
-// don't regen LOD texture on reload
-static bool reloading = false;
 #endif
 
 #if RETRO_PLATFORM == RETRO_KALLISTIOS && defined(KOS_HARDWARE_RENDERER)
@@ -247,8 +244,6 @@ void RSDK::LoadSceneFolder()
 
 #if RETRO_PLATFORM == RETRO_KALLISTIOS
     ReleaseLODTexture();
-    // default to full load, not reload
-    reloading = false;
     // book-keeping, are we in a ufo stage
     ufoNum = 0;
     if (strstr(sceneInfo.listData[sceneInfo.listPos].folder, "UFO1")) {
@@ -322,9 +317,6 @@ void RSDK::LoadSceneFolder()
         }
 #endif
 
-#if RETRO_PLATFORM == RETRO_KALLISTIOS
-        reloading = true;
-#endif
         return;
     }
 #endif
@@ -346,9 +338,6 @@ void RSDK::LoadSceneFolder()
                 }
             }
         }
-#endif
-#if RETRO_PLATFORM == RETRO_KALLISTIOS
-        reloading = true;
 #endif
         return;
     }

--- a/RSDKv5/RSDK/Scene/Scene.cpp
+++ b/RSDKv5/RSDK/Scene/Scene.cpp
@@ -2277,7 +2277,7 @@ void RSDK::DrawLayerVScroll(TileLayer *layer)
 #define recip1k 0.00097656f
 
 void rayIntersect(Vector4f cam, Vector4f forward, Vector4f right, Vector4f up, int screenX, int screenY, float *hitX, float *hitZ) {
-    float px = (float)screenX - ((float)DEFAULT_PIXWIDTH*0.5f);
+    float px = (float)screenX - ((float)320*0.5f);
     float py = 120.0f - (float)screenY;
     float nx = px * recip200;
     float ny = py * recip200;
@@ -2381,7 +2381,7 @@ void RSDK::DrawLayerRotozoom(TileLayer *layer)
     float dfc = fipr(forward.x, forward.y, forward.z, 0, cam.x, cam.y, cam.z, 0);
 
     // leaving this here to show how f and foa were derived
-    const float aspect = (float)DEFAULT_PIXWIDTH / 240.0f;
+    const float aspect = (float)320 / 240.0f;
     const float fovy   = 47.5f * RSDK_PI / 180.0f;
     const float f      = 1.0f / tanf(fovy * 0.5f);
     const float foa    = f / aspect;
@@ -2396,10 +2396,10 @@ void RSDK::DrawLayerRotozoom(TileLayer *layer)
 
     // ndc to screenspace matrix
     const float __attribute__((aligned(32))) screenspace[4][4] = {
-        {  ((float)DEFAULT_PIXWIDTH*0.5f),    0.0f, 0.0f, 0.0f },
+        {  ((float)320*0.5f),    0.0f, 0.0f, 0.0f },
         {                            0.0f, -120.0f, 0.0f, 0.0f, },
         {                            0.0f,    0.0f, 0.5f, 0.0f, },
-        {  ((float)DEFAULT_PIXWIDTH*0.5f),  120.0f, 0.5f, 1.0f, },
+        {  ((float)320*0.5f),  120.0f, 0.5f, 1.0f, },
     };
 
     // store result of load/apply to use for early-out -w test
@@ -2652,7 +2652,7 @@ void RSDK::DrawLayerRotozoom(TileLayer *layer)
 
                 // screen edge culling
                 if (ul.x < 0 && ur.x < 0 && ll.x < 0 && lr.x < 0) continue;
-                if (ul.x > DEFAULT_PIXWIDTH && ur.x > DEFAULT_PIXWIDTH && ll.x > DEFAULT_PIXWIDTH && lr.x > DEFAULT_PIXWIDTH) continue;
+                if (ul.x > 320 && ur.x > 320 && ll.x > 320 && lr.x > 320) continue;
                 if (ul.y > 240 && ur.y > 240 && ll.y > 240 && lr.y > 240) continue;
 
                 // UVs from tile-aligned grid boundaries (exact tile indices)
@@ -2909,7 +2909,7 @@ void RSDK::DrawLayerRotozoom(TileLayer *layer)
             }
 
             // off right side of screen
-            if (tileVerts[0].x > DEFAULT_PIXWIDTH && tileVerts[1].x > DEFAULT_PIXWIDTH && tileVerts[2].x > DEFAULT_PIXWIDTH && tileVerts[3].x > DEFAULT_PIXWIDTH)  {
+            if (tileVerts[0].x > 320 && tileVerts[1].x > 320 && tileVerts[2].x > 320 && tileVerts[3].x > 320)  {
                 cantReuse = true;
                 continue;
             }

--- a/RSDKv5/RSDK/Scene/Scene.cpp
+++ b/RSDKv5/RSDK/Scene/Scene.cpp
@@ -67,6 +67,14 @@ static bool reloading = false;
 #endif
 
 #if RETRO_PLATFORM == RETRO_KALLISTIOS && defined(KOS_HARDWARE_RENDERER)
+static void ReleaseLODTexture()
+{
+    if (mapSurf.texture != nullptr) {
+        pvr_mem_free(mapSurf.texture);
+        mapSurf.texture = nullptr;
+    }
+}
+
 static void GenerateLODTexture()
 {
     lodTextureReady = false;
@@ -76,10 +84,7 @@ static void GenerateLODTexture()
         return;
     }
 
-    if (mapSurf.texture != nullptr) {
-        pvr_mem_free(mapSurf.texture);
-        mapSurf.texture = nullptr;
-    }
+    ReleaseLODTexture();
 
     if (ufoNum) {
         uint8 *tilesetData = persistTiles;
@@ -241,6 +246,7 @@ void RSDK::LoadSceneFolder()
     sceneInfo.milliseconds = 0;
 
 #if RETRO_PLATFORM == RETRO_KALLISTIOS
+    ReleaseLODTexture();
     // default to full load, not reload
     reloading = false;
     // book-keeping, are we in a ufo stage
@@ -1034,7 +1040,7 @@ void RSDK::LoadSceneAssets()
 #endif
 
 #if RETRO_PLATFORM == RETRO_KALLISTIOS && defined(KOS_HARDWARE_RENDERER)
-    if (ufoNum && !reloading)
+    if (ufoNum)
         GenerateLODTexture();
 #endif
 
@@ -2657,7 +2663,7 @@ void RSDK::DrawLayerRotozoom(TileLayer *layer)
 
                 // screen edge culling
                 if (ul.x < 0 && ur.x < 0 && ll.x < 0 && lr.x < 0) continue;
-                if (ul.x > 320 && ur.x > 320 && ll.x > 320 && lr.x > 320) continue;
+                if (ul.x > DEFAULT_PIXWIDTH && ur.x > DEFAULT_PIXWIDTH && ll.x > DEFAULT_PIXWIDTH && lr.x > DEFAULT_PIXWIDTH) continue;
                 if (ul.y > 240 && ur.y > 240 && ll.y > 240 && lr.y > 240) continue;
 
                 // UVs from tile-aligned grid boundaries (exact tile indices)
@@ -2914,7 +2920,7 @@ void RSDK::DrawLayerRotozoom(TileLayer *layer)
             }
 
             // off right side of screen
-            if (tileVerts[0].x > 320 && tileVerts[1].x > 320 && tileVerts[2].x > 320 && tileVerts[3].x > 320)  {
+            if (tileVerts[0].x > DEFAULT_PIXWIDTH && tileVerts[1].x > DEFAULT_PIXWIDTH && tileVerts[2].x > DEFAULT_PIXWIDTH && tileVerts[3].x > DEFAULT_PIXWIDTH)  {
                 cantReuse = true;
                 continue;
             }


### PR DESCRIPTION
fix some pvr ooms that indirectly lead to weird crashes later by making sure we always release LOD texture. even if it gives ugly results when reloading a UFO special stage in debug mode (which normal players will never end up doing)