### PR TITLE
fixes for audio issues in #40

### DIFF
--- a/RSDKv5/RSDK/Audio/Audio.cpp
+++ b/RSDKv5/RSDK/Audio/Audio.cpp
@@ -678,7 +678,7 @@ int32 RSDK::PlaySfx(uint16 sfx, uint32 loopPoint, uint32 priority)
     channels[slot].sampleLength = sfxList[sfx].length;
     channels[slot].volume       = 1.0f;
     channels[slot].pan          = 0.0f;
-    channels[slot].speed        = TO_FIXED(1);
+    channels[slot].speed        = 1.0f;
     channels[slot].soundID      = sfx;
     if (loopPoint >= 2)
         channels[slot].loop = loopPoint;

--- a/RSDKv5/RSDK/Audio/Audio.cpp
+++ b/RSDKv5/RSDK/Audio/Audio.cpp
@@ -108,7 +108,7 @@ void AudioDeviceBase::ProcessAudioMixing(void *stream, int32 length)
                         double playTime = (double)(timer_ns_gettime64() - channel->startTimeNs) * 1e-9;
                         double freq = sfxList[channel->soundID].freq;
                         // take into account playback speed for time calculation
-                        double samplesTime = ((double)channel->sampleLength / freq) * / channel->speed;
+                        double samplesTime = ((double)channel->sampleLength / freq) * (1.0 / channel->speed);
                         // this allows us to release channels ASAP and not rely solely on the eviction logic in PlaySfx
                         if (samplesTime <= playTime) {
                                 channel->state   = CHANNEL_IDLE;

--- a/RSDKv5/RSDK/Audio/Audio.cpp
+++ b/RSDKv5/RSDK/Audio/Audio.cpp
@@ -107,7 +107,8 @@ void AudioDeviceBase::ProcessAudioMixing(void *stream, int32 length)
                         //   based on sample count and frequency
                         double playTime = (double)(timer_ns_gettime64() - channel->startTimeNs) * 1e-9;
                         double freq = sfxList[channel->soundID].freq;
-                        double samplesTime = (double)channel->sampleLength / freq;
+                        // take into account playback speed for time calculation
+                        double samplesTime = ((double)channel->sampleLength / freq) * / channel->speed;
                         // this allows us to release channels ASAP and not rely solely on the eviction logic in PlaySfx
                         if (samplesTime <= playTime) {
                                 channel->state   = CHANNEL_IDLE;


### PR DESCRIPTION
Fix the initial sfx channel speed value and use channel speed for playback time calculations. Fixes some issues with the use of `SetChannelAttributes` for modifying sfx playback params. Resolves points 1 and 2 in #40 