### PR TITLE
Added -fpermissive compiler option to CmakeLists.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,8 @@ target_compile_definitions(RetroEngine PRIVATE
     DECOMP_VERSION="${DECOMP_VERSION}"
 )
 
+target_compile_options(RetroEngine PUBLIC "-fpermissive")
+
 if(WITH_RSDK)
     if(NOT GAME_STATIC)
         add_custom_command(TARGET RetroEngine POST_BUILD


### PR DESCRIPTION
This should allow for Mania to now build perfectly fine on KOS's master branch, where the PVR API's types have moved from stupid-ass integers with lists of #defines to actual strongly typed enumerations (like they always should've been).

As a result, though, the game code would have to change to accommodate by using the new enum types, but this would break the build on old versions of KOS that predate the enums.

The best solution is just to add -fpermissive to allow the same code to work with new KOS, so that it doesn't require using its new enum types.