### PR TITLE
Fixed Hydrocity Act 2 OOM with GCC15.

### DIFF
--- a/RSDKv5/RSDK/Audio/KallistiOS/KallistiOSStream.cpp
+++ b/RSDKv5/RSDK/Audio/KallistiOS/KallistiOSStream.cpp
@@ -121,7 +121,7 @@ int stream_init(void)
     stream.status = SNDDEC_STATUS_NULL;
     stream.callback = NULL;
     audio_attr.create_detached = 0;
-    audio_attr.stack_size = 32768;
+    audio_attr.stack_size = 16768;
     audio_attr.stack_ptr = NULL;
     audio_attr.prio = PRIO_DEFAULT;
     audio_attr.label = "MusicPlayer";

--- a/RSDKv5/RSDK/Storage/Storage.cpp
+++ b/RSDKv5/RSDK/Storage/Storage.cpp
@@ -88,7 +88,7 @@ bool32 RSDK::InitStorage()
 #if RETRO_PLATFORM == RETRO_KALLISTIOS  /* SAYGA DREAMCAST: Where Sonic Belongs! */
                                                                        // RAM: 32  / 16  MB
                                                                        // -----------------
-    dataStorage[DATASET_STG].storageLimit = 700000 + (DBL_MEM? 4 : 4) * 1024 * 1024; // 4.7   / 4.7   MB
+    dataStorage[DATASET_STG].storageLimit = 700000 + (DBL_MEM? 6 : 4) * 1024 * 1024; // 4.7   / 4.7   MB
     dataStorage[DATASET_STR].storageLimit = (DBL_MEM? 3 : 3) * 32 * 1024; // 96  / 96  KB
     dataStorage[DATASET_TMP].storageLimit = 150000 + (DBL_MEM? 6 : 3) * 1024 * 1024; // 6.15   / 3.15   MB
                                                                      //   -----------------


### PR DESCRIPTION
1) KallistiOSStream.cpp
    - Gave us back 16KB of RAM by halving the size of the stack for the
      BGM stream thread. Still works great.
2) Storage.cpp
    - Doubled back up buffer sizes for 32MB modded DCs, cuz... I should
      never OOM. lol.