### PR TITLE
Update SH4ZAM to use latest in kos-ports.

### DIFF
--- a/RSDKv5/RSDK/Core/Math.cpp
+++ b/RSDKv5/RSDK/Core/Math.cpp
@@ -4,16 +4,7 @@
 using namespace RSDK;
 
 #if RETRO_PLATFORM == RETRO_KALLISTIOS && !RETRO_USE_ORIGINAL_CODE
-//! Calculates 1.0f/sqrtf( \p x ), using a fast approximation.
-__always_inline float shz_inverse_sqrtf(float x) {
-    asm("fsrra %0" : "+f" (x));
-    return x;
-}
-
-__always_inline float shz_invf(float x) {
-    float rx = shz_inverse_sqrtf(x * x);
-    return x < 0 ? -rx : rx;
-}
+#include <sh4zam/shz_sh4zam.h>
 #endif
 
 #if RETRO_PLATFORM != RETRO_KALLISTIOS || RETRO_USE_ORIGINAL_CODE

--- a/RSDKv5/RSDK/Graphics/KallistiOS/KallistiOSRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/KallistiOS/KallistiOSRenderDevice.cpp
@@ -4,6 +4,8 @@
 #include <RSDK/Core/Stub.hpp>
 #include <RSDK/Core/Math.hpp>
 
+#include <sh4zam/shz_sh4zam.h>
+
 struct KOSTexture
 {
 #if !defined(KOS_HARDWARE_RENDERER)
@@ -17,26 +19,6 @@ struct KOSTexture
 };
 
 static KOSTexture screenTextures[SCREEN_COUNT] {};
-
-// ========== FAST SH4 UTILITY ROUTINES ==========
-
-//! Calculates 1.0f/sqrtf( \p x ), using a fast approximation.
-__always_inline float shz_inverse_sqrtf(float x) {
-    asm("fsrra %0" : "+f" (x));
-    return x;
-}
-
-//! Takes the inverse of \p p using a very fast approximation, returning a positive result.
-__always_inline float shz_inverse_posf(float x) {
-    return shz_inverse_sqrtf(x * x);
-}
-
-//! Divides \p num by \p denom using a very fast approximation, returning a positive result.
-__always_inline float shz_div_posf(float num, float denom) {
-    return num * shz_inverse_posf(denom);
-}
-
-// ===============================================
 
 // Global pixel scale factors based on pixel-to-screen size ratio
 static float pixelScaleX = 1.0f;
@@ -953,10 +935,10 @@ void RenderDevice::DrawTexturedQuadPT(
     const float x1 = x0 + (static_cast<float>(width) * pixelScaleX);
     const float y0 = static_cast<float>(y) * pixelScaleY;
     const float y1 = y0 + (static_cast<float>(height) * pixelScaleY);
-    const float u0 = shz_div_posf(sprX0, surface->width);
-    const float v0 = shz_div_posf(sprY0, surface->height);
-    const float u1 = shz_div_posf(sprX1, surface->width);
-    const float v1 = shz_div_posf(sprY1, surface->height);
+    const float u0 = shz_divf_fsrra(sprX0, surface->width);
+    const float v0 = shz_divf_fsrra(sprY0, surface->height);
+    const float u1 = shz_divf_fsrra(sprX1, surface->width);
+    const float v1 = shz_divf_fsrra(sprY1, surface->height);
     const float z  = GetDepth();
 
     // First 32 bytes of a `pvr_sprite_txr_t` structure mapped to a SQ.
@@ -1009,10 +991,10 @@ void RenderDevice::DrawTexturedQuadTR(
     const float x1 = x0 + (static_cast<float>(width) * pixelScaleX);
     const float y0 = static_cast<float>(y) * pixelScaleY;
     const float y1 = y0 + (static_cast<float>(height) * pixelScaleY);
-    const float u0 = shz_div_posf(sprX0, surface->width);
-    const float v0 = shz_div_posf(sprY0, surface->height);
-    const float u1 = shz_div_posf(sprX1, surface->width);
-    const float v1 = shz_div_posf(sprY1, surface->height);
+    const float u0 = shz_divf_fsrra(sprX0, surface->width);
+    const float v0 = shz_divf_fsrra(sprY0, surface->height);
+    const float u1 = shz_divf_fsrra(sprX1, surface->width);
+    const float v1 = shz_divf_fsrra(sprY1, surface->height);
     const float z  = GetDepth();
 
     pvr_sprite_txr_t *spr = (pvr_sprite_txr_t *)safe_pvr_vertbuf_tail(PVR_LIST_TR_POLY);
@@ -1070,10 +1052,10 @@ void RenderDevice::DrawTexturedQuadPTEx(
     };
 
     // Compute constants up-front.
-    const float u0 = shz_div_posf(sprX0, surface->width);
-    const float v0 = shz_div_posf(sprY0, surface->height);
-    const float u1 = shz_div_posf(sprX1, surface->width);
-    const float v1 = shz_div_posf(sprY1, surface->height);
+    const float u0 = shz_divf_fsrra(sprX0, surface->width);
+    const float v0 = shz_divf_fsrra(sprY0, surface->height);
+    const float u1 = shz_divf_fsrra(sprX1, surface->width);
+    const float v1 = shz_divf_fsrra(sprY1, surface->height);
     const float z  = GetDepth();
 
     // First 32 bytes of a `pvr_sprite_txr_t` structure mapped to a SQ.
@@ -1292,10 +1274,10 @@ void RenderDevice::DrawTexturedPolyPT(
     const float x1 = x0 + static_cast<float>(width);
     const float y1 = y0 + static_cast<float>(height);
     const float z  = GetDepth();
-    const float u0 = shz_div_posf(sprX0, surface->width);
-    const float v0 = shz_div_posf(sprY0, surface->height);
-    const float u1 = shz_div_posf(sprX1, surface->width);
-    const float v1 = shz_div_posf(sprY1, surface->height);
+    const float u0 = shz_divf_fsrra(sprX0, surface->width);
+    const float v0 = shz_divf_fsrra(sprY0, surface->height);
+    const float u1 = shz_divf_fsrra(sprX1, surface->width);
+    const float v1 = shz_divf_fsrra(sprY1, surface->height);
     // alpha is irrelevant for PT
     const uint32 argb = 0xFFFFFFFFu;
 
@@ -1415,10 +1397,10 @@ void RenderDevice::DrawTexturedPolyPTEx(
     };
 
     const float z  = GetDepth();
-    const float u0 = shz_div_posf(sprX0, surface->width);
-    const float v0 = shz_div_posf(sprY0, surface->height);
-    const float u1 = shz_div_posf(sprX1, surface->width);
-    const float v1 = shz_div_posf(sprY1, surface->height);
+    const float u0 = shz_divf_fsrra(sprX0, surface->width);
+    const float v0 = shz_divf_fsrra(sprY0, surface->height);
+    const float u1 = shz_divf_fsrra(sprX1, surface->width);
+    const float v1 = shz_divf_fsrra(sprY1, surface->height);
 
     pvr_vertex_t verts[4] = {
         {
@@ -1480,10 +1462,10 @@ void RenderDevice::DrawFloorTexturedPolyPTEx(
 
     lastPrimitiveWasConsumed = true;
 
-    const float u0 = shz_div_posf(sprX0, surface->width);
-    const float v0 = shz_div_posf(sprY0, surface->height);
-    const float u1 = shz_div_posf(sprX1, surface->width);
-    const float v1 = shz_div_posf(sprY1, surface->height);
+    const float u0 = shz_divf_fsrra(sprX0, surface->width);
+    const float v0 = shz_divf_fsrra(sprY0, surface->height);
+    const float u1 = shz_divf_fsrra(sprX1, surface->width);
+    const float v1 = shz_divf_fsrra(sprY1, surface->height);
 
     pvr_vertex_t verts[4] = {
         {
@@ -1561,10 +1543,10 @@ void RenderDevice::DrawTexturedPolyTR(
     const float x1 = x0 + static_cast<float>(width);
     const float y1 = y0 + static_cast<float>(height);
     const float z  = GetDepth();
-    const float u0 = shz_div_posf(sprX0, surface->width);
-    const float v0 = shz_div_posf(sprY0, surface->height);
-    const float u1 = shz_div_posf(sprX1, surface->width);
-    const float v1 = shz_div_posf(sprY1, surface->height);
+    const float u0 = shz_divf_fsrra(sprX0, surface->width);
+    const float v0 = shz_divf_fsrra(sprY0, surface->height);
+    const float u1 = shz_divf_fsrra(sprX1, surface->width);
+    const float v1 = shz_divf_fsrra(sprY1, surface->height);
     const uint32 argb = 0x00FFFFFFu | (alpha << 24);
 
     /* Since we have to potentially modify the vertex stream later on to apply

--- a/RSDKv5/RSDK/Graphics/Scene3D.cpp
+++ b/RSDKv5/RSDK/Graphics/Scene3D.cpp
@@ -17,180 +17,7 @@ using namespace RSDK;
 // ((1.0 / 0.0003345) / 1024) / 256
 #define DIFFUSE_SCALE 0.01140418f
 
-/*! 2D Vector type
- *
- *  Structure for holding coordinates of a 2-dimensional vector.
- *
- * \sa shz_vec3_t, shz_vec4_t
- */
-typedef struct shz_vec2 {
-    union {
-        float e[2]; //!< <X, Y> coordinates as an array
-        struct {
-            float x; //!< X coordinate
-            float y; //!< Y coordinate
-        };
-    };
-} shz_vec2_t;
-
-/*! 3D Vector type
- *
- *  Structure for holding coordinates of a 3-dimensional vector.
- *
- * \sa shz_vec2_t, shz_vec4_t
- */
-typedef struct shz_vec3 {
-    union {
-        float e[3]; //!< <X, Y, Z> coordinates as an array
-        struct {
-            union {
-                struct {
-                    float x; //!< X coordinate
-                    float y; //!< Y coordinate
-                };
-                shz_vec2_t xy; //!< Inner 2D vector containing <X, Y> coords
-            };
-            float z; //!< Z coordinate
-        };
-    };
-} shz_vec3_t;
-
-/*! 4D Vector type
- *
- *  Structure for holding coordinates of a 4-dimensional vector.
- *
- *  \sa shz_vec2_t, shz_vec3_t
- */
-typedef struct shz_vec4 {
-    union {
-        float e[4]; //!< <X, Y, Z, W> coordinates as an array.
-        struct {
-            union {
-                struct {
-                    float x; //!< X coordinate
-                    float y; //!< Y coordinate
-                    float z; //!< Z coordinate
-                };
-                shz_vec3_t xyz; //!< <X, Y, Z> coordinates as a 3D vector
-            };
-            float w; //!< W coordinate
-        };
-        struct {
-            shz_vec2_t xy; //!< <X, Y> coordinates as a 2D vector
-            shz_vec2_t zw; //!< <Z, W> coordinates as a 2D vector
-        };
-    };
-} shz_vec4_t;
-typedef __attribute__((aligned(8))) union shz_matrix_4x4 {
-    float elem[16];
-    float elem2D[4][4];
-    shz_vec4_t col[4];
-    struct {
-        shz_vec4_t left;
-        shz_vec4_t up;
-        shz_vec4_t forward;
-        shz_vec4_t pos;
-    };
-} shz_matrix_4x4_t;
-
-//! Calculates 1.0f/sqrtf( \p x ), using a fast approximation.
-__always_inline float shz_inverse_sqrtf(float x) {
-    asm("fsrra %0" : "+f" (x));
-    return x;
-}
-
-__always_inline float shz_invf(float x) {
-    float rx = shz_inverse_sqrtf(x * x);
-    return x < 0 ? -rx : rx;
-}
-
-__always_inline float shz_divf(float num, float denom) {
-    return num * shz_invf(denom);
-}
-
-__always_inline void shz_xmtrx_load_4x4(const shz_matrix_4x4_t* matrix) {
-    asm volatile(R"(
-        fschg
-        fmov.d	@%[mtx], xd0
-        add     #32, %[mtx]
-        pref	@%[mtx]
-        add     #-(32-8), %[mtx]
-        fmov.d	@%[mtx]+, xd2
-        fmov.d	@%[mtx]+, xd4
-        fmov.d	@%[mtx]+, xd6
-        fmov.d	@%[mtx]+, xd8
-        fmov.d	@%[mtx]+, xd10
-        fmov.d	@%[mtx]+, xd12
-        fmov.d	@%[mtx]+, xd14
-        fschg
-    )"
-                 : [mtx] "+r"(matrix)
-                 : "m"(*matrix));
-}
-
-__always_inline void shz_xmtrx_load_apply_store_4x4(shz_matrix_4x4_t* out, const shz_matrix_4x4_t* matrix1,
-                                               const shz_matrix_4x4_t* matrix2) {
-    unsigned int prefetch_scratch;
-
-    asm volatile(R"(
-        mov     %[m1], %[prefscr]
-        add     #32, %[prefscr]
-        fschg
-        pref    @%[prefscr]
-
-        fmov.d  @%[m1]+, xd0
-        fmov.d  @%[m1]+, xd2
-        fmov.d  @%[m1]+, xd4
-        fmov.d  @%[m1]+, xd6
-        pref    @%[m1]
-        fmov.d  @%[m1]+, xd8
-        fmov.d  @%[m1]+, xd10
-        fmov.d  @%[m1]+, xd12
-        mov     %[m2], %[prefscr]
-        add     #32, %[prefscr]
-        fmov.d  @%[m1], xd14
-        pref    @%[prefscr]
-
-        fmov.d  @%[m2]+, dr0
-        fmov.d  @%[m2]+, dr2
-        fmov.d  @%[m2]+, dr4
-        ftrv    xmtrx, fv0
-
-        fmov.d  @%[m2]+, dr6
-        fmov.d  @%[m2]+, dr8
-        ftrv    xmtrx, fv4
-
-        fmov.d  @%[m2]+, dr10
-        fmov.d  @%[m2]+, dr12
-        ftrv    xmtrx, fv8
-
-        add     #16, %[out]
-        fmov.d  dr2, @-%[out]
-        fmov.d  dr0,  @-%[out]
-
-        fmov.d  @%[m2], dr14
-        ftrv    xmtrx, fv12
-
-        add     #32, %[out]
-        fmov.d  dr6, @-%[out]
-        fmov.d  dr4, @-%[out]
-
-        add     #32, %[out]
-        fmov.d  dr10, @-%[out]
-        fmov.d  dr8, @-%[out]
-
-        add     #32, %[out]
-        fmov.d  dr14, @-%[out]
-        fmov.d  dr12, @-%[out]
-
-        fschg
-    )"
-                 : [m1] "+&r"(matrix1), [m2] "+r"(matrix2), [out] "+&r"(out),
-                   "=m"(*out), [prefscr] "=&r"(prefetch_scratch)
-                 : "m"(*matrix1), "m"(*matrix2)
-                 : "fr0", "fr1", "fr2", "fr3", "fr4", "fr5", "fr6", "fr7", "fr8", "fr9", "fr10", "fr11", "fr12", "fr13",
-                   "fr14", "fr15");
-}
+#include <sh4zam/shz_sh4zam.h>
 #endif
 
 #if RETRO_PLATFORM == RETRO_KALLISTIOS
@@ -428,7 +255,7 @@ void RSDK::MatrixMultiply(Matrix *dest, Matrix *matrixA, Matrix *matrixB)
 
     float __attribute__((aligned(32))) xmtrxC[16];
     int32 *mtrxC = (int32 *)dest->values;
-    shz_xmtrx_load_apply_store_4x4((shz_matrix_4x4_t*)xmtrxC, (const shz_matrix_4x4_t*)xmtrxA, (const shz_matrix_4x4_t*)xmtrxB);
+    shz_xmtrx_load_apply_store_4x4((shz_mat4x4_t*)xmtrxC, (const shz_mat4x4_t*)xmtrxA, (const shz_mat4x4_t*)xmtrxB);
     for (int i=0;i<16;i++) {
         *mtrxC++ = ((int32)xmtrxC[i]) >> 8;
     }
@@ -876,7 +703,7 @@ void RSDK::AddModelToScene(uint16 modelFrames, uint16 sceneIndex, uint8 drawMode
                     uint32 rowB              = i % 4;
                     xmtrx[rowA][rowB] = (float)matWorld->values[rowB][rowA] * recip256;
                 }
-                shz_xmtrx_load_4x4((const shz_matrix_4x4_t*)xmtrx);
+                shz_xmtrx_load_4x4((const shz_mat4x4_t*)xmtrx);
 #endif
 
 #if RETRO_PLATFORM == RETRO_KALLISTIOS
@@ -1137,7 +964,7 @@ void RSDK::AddMeshFrameToScene(uint16 modelFrames, uint16 sceneIndex, Animator *
                     xmtrx[rowA][rowB] = (float)matWorld->values[rowB][rowA] * recip256;
                 }
 //                mat_load(&xmtrx);
-                shz_xmtrx_load_4x4((const shz_matrix_4x4_t*)xmtrx);
+                shz_xmtrx_load_4x4((const shz_mat4x4_t*)xmtrx);
 #endif
 
 #if RETRO_PLATFORM == RETRO_KALLISTIOS

--- a/RSDKv5/RSDK/Scene/Scene.cpp
+++ b/RSDKv5/RSDK/Scene/Scene.cpp
@@ -2,21 +2,7 @@
 
 #ifdef KOS_HARDWARE_RENDERER
 #include <RSDK/Graphics/KallistiOS/AniTileTracker.hpp>
-
-//! Calculates 1.0f/sqrtf( \p x ), using a fast approximation.
-__always_inline float shz_inverse_sqrtf(float x) {
-    asm("fsrra %0" : "+f" (x));
-    return x;
-}
-
-__always_inline float shz_invf(float x) {
-    float rx = shz_inverse_sqrtf(x * x);
-    return x < 0 ? -rx : rx;
-}
-
-__always_inline float shz_divf(float num, float denom) {
-    return num * shz_invf(denom);
-}
+#include <sh4zam/shz_sh4zam.h>
 #endif
 
 using namespace RSDK;

--- a/platforms/KallistiOS.cmake
+++ b/platforms/KallistiOS.cmake
@@ -21,6 +21,8 @@ target_compile_definitions(${GAME_NAME} PUBLIC RSDK_DEBUG=$<BOOL:${RSDK_DEBUG}>)
 option(KOS_USER_DIR "Root directory for the KOS VFS which get set as the RSDK User directory." "/cd/")
 target_compile_definitions(RetroEngine PUBLIC KOS_USER_DIR="${KOS_USER_DIR}")
 
+target_link_libraries(RetroEngine sh4zam)
+
 # Disable some unneeded features to reduce executable size
 set(RETRO_MOD_LOADER OFF CACHE BOOL "Disable mod loader" FORCE)
 set(GAME_INCLUDE_EDITOR OFF CACHE BOOL "Disable unused editor code" FORCE)


### PR DESCRIPTION
Cleaned up all of the random legacy SH4ZAM shit that had been copy +
pasted throughout the codebase, and am instead linking to the sh4zam
library that is built as a standard KOS-port, plus am including its
global headers for its C API (C++ API wasn't used and requires C++20).

Everything builds and runs fine, plus a bunch of the matrix routines for
the 3D stages should have some micro gainz.