### PR TITLE
add color-key-to-alpha value for explosions sheet

### DIFF
--- a/dreamcast/gfx_step_1_toalphapng.sh
+++ b/dreamcast/gfx_step_1_toalphapng.sh
@@ -35,6 +35,7 @@ for dir in Global TMZ1 UI; do
     "${IM_CONVERT[@]}" "$file" \
       -alpha on \
       -transparent "#FF00FF" \
+      -transparent "#01F001" \
       -transparent "#00FF00" \
       -define png:color-type=6 \
       "$base.png"


### PR DESCRIPTION
We are missing one color value in `gfx_step_1_toalphapng.sh` . Without it, explosions sheet has green background. Other purple and green transparent sheet areas were being made transparent like they should.

This one-line change fixes that.