### PR TITLE
Implement missing visual effects on Dreamcast

### DIFF
--- a/RSDKv5/RSDK/Graphics/Drawing.cpp
+++ b/RSDKv5/RSDK/Graphics/Drawing.cpp
@@ -4704,8 +4704,64 @@ void RSDK::DrawDeformedSprite(uint16 sheetID, int32 inkEffect, int32 alpha)
     }
 
 #if RETRO_PLATFORM == RETRO_KALLISTIOS && defined(KOS_HARDWARE_RENDERER)
-    // DCTODO: DrawDeformedSprite
     validDraw = true;
+
+    if (inkEffect == INK_MASKED)
+        return;
+
+    GFXSurface *surface = &gfxSurface[sheetID];
+    if (!surface->texture)
+        return;
+
+    int32 clipY1  = currentScreen->clipBound_Y1;
+    int32 clipY2  = currentScreen->clipBound_Y2;
+    int32 screenW = currentScreen->pitch;
+
+    uint32 argb = ((uint32)alpha << 24) | 0x00FFFFFF;
+
+    RenderDevice::PrepareTexturedPolyTREX(clipY1, inkEffect, surface);
+
+    float z      = RenderDevice::GetDepth();
+    int32 stripH = 4;
+    float texW   = (float)surface->width;
+    float texH   = (float)surface->height;
+
+    float baseV = fmodf((float)scanlines[clipY1].position.y / 65536.0f, texH);
+    if (baseV < 0.0f)
+        baseV += texH;
+
+    for (int32 y = clipY1; y < clipY2; y += stripH) {
+        int32 botY = y + stripH;
+        if (botY > clipY2)
+            botY = clipY2;
+
+        int32 midY = (y + botY) >> 1;
+        ScanlineInfo *midScan = &scanlines[midY];
+
+        float rawX0 = (float)midScan->position.x / 65536.0f;
+        float scale = (float)midScan->deform.x / 65536.0f;
+        float span  = (float)screenW * scale;
+        float sprX0 = fmodf(rawX0, texW);
+        if (sprX0 < 0.0f)
+            sprX0 += texW;
+        float sprX1 = sprX0 + span;
+
+        float sprY0 = fmodf(baseV + (float)(y - clipY1), texH);
+        if (sprY0 < 0.0f)
+            sprY0 += texH;
+        float sprY1 = sprY0 + (float)(botY - y);
+
+        Vector4f ul = { 0.0f, (float)y, z, 1.0f };
+        Vector4f ur = { (float)screenW, (float)y, z, 1.0f };
+        Vector4f ll = { 0.0f, (float)botY, z, 1.0f };
+        Vector4f lr = { (float)screenW, (float)botY, z, 1.0f };
+
+        RenderDevice::DrawFloorTexturedPolyTREx(
+            ul, ur, ll, lr,
+            sprX0, sprX1, sprY0, sprY1,
+            surface, argb, 0x00000000
+        );
+    }
 #else
     validDraw              = true;
     GFXSurface *surface    = &gfxSurface[sheetID];

--- a/RSDKv5/RSDK/Graphics/Sprite.cpp
+++ b/RSDKv5/RSDK/Graphics/Sprite.cpp
@@ -1210,6 +1210,37 @@ uint16 RSDK::LoadSpriteSheet(const char *filename, uint8 scope)
 
                     printPvrMem(pvrMemBefore, pvrMemAfter);
 
+                    // Patch the wing sprite's mask pixels (palette 55) to per-row palette
+                    // indices so we can animate the fringe color per-row via palette cycling.
+                    // Free indices: 62-127 (66) + 45,46,47 (3) + 152,162,163,167,172,173,174 (7) + 245,246 (2) = 78
+                    if (strstr(filename, "Title/Logo.gif")) {
+                        static const uint8 fringeIndices[] = {
+                            62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,
+                            90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,
+                            114,115,116,117,118,119,120,121,122,123,124,125,126,127,
+                            45,46,47,152,162,163,167,172,173,174,245,246
+                        };
+                        uint8 *px   = surface->pixels;
+                        int32 w     = surface->width;
+                        int32 count = 0;
+                        for (int32 y = 8; y <= 89; y++) {
+                            bool hasMaskPixel = false;
+                            for (int32 x = 1; x <= 145; x++) {
+                                if (px[y * w + x] == 55) {
+                                    hasMaskPixel = true;
+                                    break;
+                                }
+                            }
+                            if (hasMaskPixel && count < (int32)sizeof(fringeIndices)) {
+                                for (int32 x = 1; x <= 145; x++) {
+                                    if (px[y * w + x] == 55)
+                                        px[y * w + x] = fringeIndices[count];
+                                }
+                                count++;
+                            }
+                        }
+                    }
+
                     // pvr_txr_load_ex is used instead of pvr_txr_load because _ex twiddles automatically,
                     // which is useful since PVR palettized textures must be twiddled (apparently? see pvr.h).
                     // pvr_txr_load_ex actually *always* twiddles, even if you don't want it.


### PR DESCRIPTION
**OOZ Smog (DrawDeformedSprite):** Implements the DC path for DrawDeformedSprite using horizontal strip quads on the TR (translucent) list. Each 4-pixel strip samples the scanline deformation table at its midpoint for UV displacement. Uses proper fixed-to-float conversion (dividing by 65536.0f instead of FROM_FIXED integer truncation). Smog uses INK_ALPHA at 0x60 instead of the unsupported INK_BLEND.

**CPZ2 ParallaxSprite SHIFT (INK_MASKED workaround):** On DC, draws the scrolling wave sprites behind the foreground at a lower Z depth instead of using INK_MASKED. The foreground tiles' transparent regions let the waves show through. Expands clip bounds before drawing to prevent premature culling when the sprite scrolls partially offscreen.

**Title Screen Wing Shine:** Patches the wing emblem sprite at load time, replacing the mask-color palette index (55) with per-row palette indices from unused palette slots. Each frame, cycles those palette entries through a 7-color purple/blue gradient with a 32-step pattern, recreating the animated shimmer that the original achieves via INK_MASKED with a large sprite overlay.