### PR TITLE
Animation Freeing for Zones Rendering

### DIFF
--- a/RSDKv5/RSDK/Core/Link.cpp
+++ b/RSDKv5/RSDK/Core/Link.cpp
@@ -413,6 +413,9 @@ void RSDK::SetupFunctionTables()
 
     // Sprite Animations & Frames
     ADD_RSDK_FUNCTION(FunctionTable_LoadSpriteAnimation, LoadSpriteAnimation);
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
+    ADD_RSDK_FUNCTION(FunctionTable_FreeSpriteAnimation, FreeSpriteAnimation);
+#endif
     ADD_RSDK_FUNCTION(FunctionTable_CreateSpriteAnimation, CreateSpriteAnimation);
     ADD_RSDK_FUNCTION(FunctionTable_SetSpriteAnimation, SetSpriteAnimation);
     ADD_RSDK_FUNCTION(FunctionTable_EditSpriteAnimation, EditSpriteAnimation);

--- a/RSDKv5/RSDK/Core/Link.hpp
+++ b/RSDKv5/RSDK/Core/Link.hpp
@@ -226,6 +226,9 @@ enum FunctionTableIDs {
     FunctionTable_AddMeshFrameToScene,
     FunctionTable_Draw3DScene,
     FunctionTable_LoadSpriteAnimation,
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
+    FunctionTable_FreeSpriteAnimation,
+#endif
     FunctionTable_CreateSpriteAnimation,
     FunctionTable_SetSpriteAnimation,
     FunctionTable_EditSpriteAnimation,

--- a/RSDKv5/RSDK/Graphics/Animation.cpp
+++ b/RSDKv5/RSDK/Graphics/Animation.cpp
@@ -115,6 +115,45 @@ uint16 RSDK::LoadSpriteAnimation(const char *filePath, uint8 scope)
     return -1;
 }
 
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
+void RSDK::FreeSpriteAnimation(uint16 aniFrames)
+{
+    if (aniFrames >= SPRFILE_COUNT)
+        return;
+
+    SpriteAnimation *spr = &spriteAnimationList[aniFrames];
+    if (spr->scope == SCOPE_NONE)
+        return;
+
+    uint8 freedSheets[SURFACE_COUNT];
+    memset(freedSheets, 0, sizeof(freedSheets));
+
+    int32 totalFrames = 0;
+    for (int32 a = 0; a < spr->animCount; ++a)
+        totalFrames += spr->animations[a].frameCount;
+
+    for (int32 f = 0; f < totalFrames; ++f) {
+        uint8 sheetID = spr->frames[f].sheetID;
+        if (sheetID >= SURFACE_COUNT || freedSheets[sheetID])
+            continue;
+
+        freedSheets[sheetID] = 1;
+        GFXSurface *surface  = &gfxSurface[sheetID];
+
+        if (surface->texture != nullptr) {
+            pvr_mem_free(surface->texture);
+            surface->texture = nullptr;
+        }
+
+        MEM_ZERO(*surface);
+        surface->scope = SCOPE_NONE;
+    }
+
+    MEM_ZERO(*spr);
+    spr->scope = SCOPE_NONE;
+}
+#endif
+
 uint16 RSDK::CreateSpriteAnimation(const char *filename, uint32 frameCount, uint32 animCount, uint8 scope)
 {
     if (!scope || scope > SCOPE_STAGE)

--- a/RSDKv5/RSDK/Graphics/Animation.hpp
+++ b/RSDKv5/RSDK/Graphics/Animation.hpp
@@ -81,6 +81,9 @@ extern SpriteAnimation spriteAnimationList[SPRFILE_COUNT];
 
 uint16 LoadSpriteAnimation(const char *filename, uint8 scope);
 uint16 CreateSpriteAnimation(const char *filename, uint32 frameCount, uint32 animCount, uint8 scope);
+#if RETRO_PLATFORM == RETRO_KALLISTIOS
+void FreeSpriteAnimation(uint16 aniFrames);
+#endif
 
 inline uint16 FindSpriteAnimation(uint16 aniFrames, const char *name)
 {

--- a/dreamcast/generate_assets.sh
+++ b/dreamcast/generate_assets.sh
@@ -68,6 +68,8 @@ rm -f -- "$stagedir/Sprites/UI/Achievements.gif"
 
 # fix for the main menu backgrounds
 rm -f -- "$stagedir/Sprites/UI/Diorama2.gif"
+# fix for the save select zone icons
+rm -f -- "$stagedir/Sprites/UI/Zones.gif"
 
 "$script_dir/model_process.sh"              "$sourcedir" "$stagedir"
 


### PR DESCRIPTION
Added FreeSpriteAnimation to swap Diorama2 and Zones.gif VRAM on DC so save select zone icons render with correct palettes.
<img width="588" height="342" alt="Screenshot 2026-06-05 at 10 52 24 PM" src="https://github.com/user-attachments/assets/53c0c370-a42c-4520-9f46-03872d9f6071" />