### PR TITLE
Pause Menu INK_TINT desaturation implementation

### DIFF
--- a/RSDKv5/RSDK/Graphics/Drawing.cpp
+++ b/RSDKv5/RSDK/Graphics/Drawing.cpp
@@ -2804,7 +2804,7 @@ void RSDK::DrawBlendedFace(Vector2 *vertices, uint32 *colors, int32 vertCount, i
 #if RETRO_PLATFORM == RETRO_KALLISTIOS && defined(KOS_HARDWARE_RENDERER)
     // DC_DESATURATE: desaturate per-vertex colors when paused, but not for the pause menu's own draw group
     uint8 desat = RenderDevice::GetPaletteDesaturation();
-    uint32 localColors[256];
+    uint32 localColors[4];
     if (desat > 0 && sceneInfo.currentDrawGroup < DRAWGROUP_COUNT - 1) {
         for (int32 v = 0; v < vertCount; ++v)
             localColors[v] = DesaturateColor32(colors[v], desat);


### PR DESCRIPTION
Since I started going for as much accuracy as possible, I put in the work to make the pause menu produce the same desaturated grayscale result as the original INK_TINT / tint table effect.