### PR TITLE
Claw back some VRAM

### DIFF
--- a/RSDKv5/RSDK/Graphics/KallistiOS/KallistiOSRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/KallistiOS/KallistiOSRenderDevice.cpp
@@ -192,9 +192,9 @@ bool RenderDevice::Init()
 
         // vertex buffer size
         // 512 KB is the default used by pvr_init_defaults().
-        // we have now given it 1 mb.
+        // we have now given it 768 kb.
         // might need adjusting in the future.
-        1024 * 1024,
+        768 * 1024,
 
         // dma enabled? (yes)
         1,

--- a/RSDKv5/RSDK/Graphics/Sprite.cpp
+++ b/RSDKv5/RSDK/Graphics/Sprite.cpp
@@ -1089,10 +1089,17 @@ uint16 RSDK::LoadVQSpriteSheet(const char *filename, uint8 scope) {
 uint16 RSDK::LoadSpriteSheet(const char *filename, uint8 scope)
 {
 #if RETRO_PLATFORM == RETRO_KALLISTIOS && defined(KOS_HARDWARE_RENDERER)
-    if ((strncmp("TMZ1/Portal", filename, 11) == 0) || (strncmp("TMZ1/MonarchBottom.gif", filename, 21) == 0) || (strncmp("TMZ1/MonarchTop.gif", filename, 18) == 0) || (strncmp("Global/", filename, 7) == 0) || (strncmp("UI/", filename, 3) == 0)) {
+    if ((strncmp("SpecialBS", filename, 9) == 0) || (strncmp("TMZ1/Portal", filename, 11) == 0) || (strncmp("TMZ1/MonarchBottom.gif", filename, 21) == 0) || (strncmp("TMZ1/MonarchTop.gif", filename, 18) == 0) || (strncmp("Global/", filename, 7) == 0) || (strncmp("UI/", filename, 3) == 0)) {
         uint16_t id = LoadVQSpriteSheet(filename, scope);
         if (id != (uint16_t)-1) {
             return id;
+        }
+    }
+
+    // skip sheets that cause PVR OOM on GHZCutscene
+    if (strncmp(currentSceneFolder, "GHZCut", 6) == 0) {
+        if (strstr(filename, "Shields.gif") || strstr(filename, "SuperButtons.gif") || strstr(filename, "SmallFont1.gif") || strstr(filename, "SmallFont2.gif")) {
+            return (uint16)-1;
         }
     }
 #endif


### PR DESCRIPTION
Take a small amount of vram from vertbuf and give it back to textures, along with preventing a bad OOM in GHZ Cutscene by explicitly denying the loading of a few sprite sheets that dont get rendered.