### PR TITLE
small fix for the tails' tail shop window issue

### DIFF
--- a/RSDKv5/RSDK/Graphics/Drawing.cpp
+++ b/RSDKv5/RSDK/Graphics/Drawing.cpp
@@ -3475,10 +3475,19 @@ void RSDK::DrawSprite(Animator *animator, Vector2 *position, bool32 screenRelati
             int32 camX = currentScreen->position.x;
             int32 camY = currentScreen->position.y;
 
-            int32 sprLeft   = pos.x - frame->width - abs(frame->pivotX);
-            int32 sprTop    = pos.y - frame->height - abs(frame->pivotY);
-            int32 sprRight  = pos.x + frame->width + abs(frame->pivotX);
-            int32 sprBottom = pos.y + frame->height + abs(frame->pivotY);
+            int32 sprLeft, sprTop, sprRight, sprBottom;
+            if (drawFX & FX_ROTATE) {
+                int32 maxExt = MAX(frame->width + abs(frame->pivotX), frame->height + abs(frame->pivotY));
+                sprLeft   = pos.x - maxExt;
+                sprTop    = pos.y - maxExt;
+                sprRight  = pos.x + maxExt;
+                sprBottom = pos.y + maxExt;
+            } else {
+                sprLeft   = pos.x - frame->width - abs(frame->pivotX);
+                sprTop    = pos.y - frame->height - abs(frame->pivotY);
+                sprRight  = pos.x + frame->width + abs(frame->pivotX);
+                sprBottom = pos.y + frame->height + abs(frame->pivotY);
+            }
 
             for (int32 r = 0; r < silhouetteRegionCount; ++r) {
                 SilhouetteRegion *region = &silhouetteRegions[r];

--- a/RSDKv5/RSDK/Graphics/Drawing.cpp
+++ b/RSDKv5/RSDK/Graphics/Drawing.cpp
@@ -3539,7 +3539,7 @@ void RSDK::DrawSprite(Animator *animator, Vector2 *position, bool32 screenRelati
                     case FX_SCALE | FX_ROTATE | FX_FLIP:
                         // DC_SILHOUETTE: rotated sprites can't be clipped to region bounds,
                         // so only silhouette if left edge is inside the region
-                        if (sprLeft >= rgnX1 && sprLeft < rgnX2 && pos.y >= rgnY1 && pos.y < rgnY2)
+                        if (sprLeft >= rgnX1 && sprLeft < rgnX2 && sprBottom > rgnY1 && pos.y < rgnY2)
                             DrawSpriteRotozoom(pos.x, pos.y, frame->pivotX, frame->pivotY, frame->width, frame->height, frame->sprX, frame->sprY,
                                                (drawFX & FX_SCALE) ? sceneInfo.entity->scale.x : 0x200,
                                                (drawFX & FX_SCALE) ? sceneInfo.entity->scale.y : 0x200,

--- a/RSDKv5/RSDK/Graphics/Drawing.cpp
+++ b/RSDKv5/RSDK/Graphics/Drawing.cpp
@@ -3539,7 +3539,7 @@ void RSDK::DrawSprite(Animator *animator, Vector2 *position, bool32 screenRelati
                     case FX_SCALE | FX_ROTATE | FX_FLIP:
                         // DC_SILHOUETTE: rotated sprites can't be clipped to region bounds,
                         // so only silhouette if left edge is inside the region
-                        if (sprLeft >= rgnX1 && sprLeft < rgnX2 && sprBottom > rgnY1 && pos.y < rgnY2)
+                        if (pos.x >= rgnX1 && pos.x < rgnX2 && sprLeft >= rgnX1 && sprBottom > rgnY1 && pos.y < rgnY2)
                             DrawSpriteRotozoom(pos.x, pos.y, frame->pivotX, frame->pivotY, frame->width, frame->height, frame->sprX, frame->sprY,
                                                (drawFX & FX_SCALE) ? sceneInfo.entity->scale.x : 0x200,
                                                (drawFX & FX_SCALE) ? sceneInfo.entity->scale.y : 0x200,

--- a/RSDKv5/RSDK/Scene/Scene.cpp
+++ b/RSDKv5/RSDK/Scene/Scene.cpp
@@ -421,6 +421,8 @@ void RSDK::LoadSceneFolder()
     sceneInfo.milliseconds = 0;
 
 #if RETRO_PLATFORM == RETRO_KALLISTIOS
+    // DC_SILHOUETTE: remove regions before each level
+    ClearSilhouetteRegions();
     ReleaseLODTexture();
     ReleaseFloorTexture();
     ReleaseRoofTextures();


### PR DESCRIPTION
There's a bit of trickiness with the region check.

DrawRotozoomSprite doesn't clip, so you can't rely on that to handle incorrect masking. 

The windmills and Tails' tail were drawing incorrectly near window regions.

Tweaked the "sprite inside region" check slightly so it uses left and bottom of sprite for every check except for the position of the sprite being above the bottom of the region.